### PR TITLE
Fix: add path separator with path module

### DIFF
--- a/src/helpers/paths.js
+++ b/src/helpers/paths.js
@@ -3,7 +3,7 @@ const globule = require("globule");
 
 const { IGNORE, ALIAS, TYPES } = require("../constants/settings");
 
-const PATH_SEP = "/";
+const PATH_SEP = path.sep;
 const NODE_MODULES = "node_modules";
 const INDEX = "index.js";
 


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

With this change, the library path detects the OS path separator and the file detection on OS windows is fixed for prefer recognized types.

**Closing issues**

Close #30 