### PR TITLE
Disallow the usage of only some destructured imports in no-external rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 ### Added
+- feat(no-external): Allow forbid importing external libraries specifiers
+- fix(no-external): Do not allow importing subfolders of forbidden external libraries
+
 ### Changed
 ### Fixed
 ### Removed

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Read the [docs of the `boundaries/allowed-types` rule](docs/rules/allowed-types.
 
 ### Forbidden external modules
 
-External dependencies used by each type of element in your project can be checked using this rule. For example, you can define that "helpers" can't import `react`, or "components" can't import  `react-router-dom`.
+External dependencies used by each type of element in your project can be checked using this rule. For example, you can define that "helpers" can't import `react`, or "components" can't import  `react-router-dom`, or modules can't import `{ Link } from react-router-dom`.
 
 Read the [docs of the `boundaries/no-external` rule](docs/rules/no-external.md) for further info.
 
@@ -82,7 +82,7 @@ So there are basic rules that have to be followed to make it work:
 * __[boundaries/no-private](docs/rules/no-private.md)__: Enforce elements to not use private elements of another element.
 * __[boundaries/entry-point](docs/rules/entry-point.md)__: Prevent other elements importing a file different from the allowed entry point.
 * __[boundaries/allowed-types](docs/rules/allowed-types.md)__: Prevent elements of one type to import any other element types not specified in the configuration of this rule.
-* __[boundaries/no-external](docs/rules/no-external.md)__: Enforce elements of one type to not use some external dependencies.
+* __[boundaries/no-external](docs/rules/no-external.md)__: Enforce elements of one type to not use some external dependencies or part of them.
 * [boundaries/prefer-recognized-types](docs/rules/prefer-recognized-types.md): Prevent creating files not recognized as any of the element types.
 * [boundaries/no-import-not-recognized-types](docs/rules/no-import-not-recognized-types.md): Prevent importing not recognized elements from the recognized ones.
 * [boundaries/no-import-ignored](docs/rules/no-import-ignored.md): Prevent importing files marked as ignored from the recognized elements.

--- a/docs/rules/no-external.md
+++ b/docs/rules/no-external.md
@@ -32,7 +32,12 @@ src/
         "forbid": {
           "helpers": ["react"],
           "components": ["react-router-dom"],
-          "modules": []
+          "modules": [
+            "material-ui",
+            {
+              "react-router-dom": ["Link"],
+            }
+          ]
         }
       }
     ]
@@ -57,9 +62,30 @@ _Components can't import `react-router-dom`:_
 import { withRouter } from "react-router-dom"
 ```
 
+_Modules can't import `material-ui`:_
+
+```js
+// src/modules/module-a/ModuleA.js
+import { Label } from "material-ui/core";
+```
+
+_Modules can't import Link from `react-router-dom`:_
+
+```js
+// src/modules/module-a/ModuleA.js
+import { Link } from "react-router-dom";
+```
+
 ### Examples of **correct** code for this rule:
 
-_Modules can import `react-router-dom`:_
+_Modules can import `react`:_
+
+```js
+// src/modules/module-a/ModuleA.js
+import React from "react"
+```
+
+_Modules can import `withRouter` from `react-router-dom` (Note in the configuration that only `Link` is forbidden for modules)._
 
 ```js
 // src/modules/module-a/ModuleA.js
@@ -75,7 +101,10 @@ import { withRouter } from "react-router-dom"
 ```
 
 * `enabled`: for enabling the rule. 0=off, 1=warn, 2=error.
-* `forbid`: Define forbidden external dependencies for each element type. (Use element type as a key in the object to define its forbidden dependencies)
+* `forbid`: Define forbidden external dependencies for each element type. (Use element type as a key in the object to define its forbidden dependencies as an array)
+  * Dependencies can be defined as:
+    * `<String>`: The name of the library not allowed to be imported.
+    * `{ <String>: [<String>, <String>]}`: An object containing a key with the library name, and and array of forbidden import specifiers as value.
 
 ```json
 {
@@ -84,7 +113,12 @@ import { withRouter } from "react-router-dom"
         "forbid": {
           "helpers": ["react"],
           "components": ["react-router-dom"],
-          "modules": []
+          "modules": [
+            "material-ui",
+            {
+              "react-router-dom": ["Link"],
+            }
+          ]
         }
       }
     ]

--- a/src/rules/no-external.js
+++ b/src/rules/no-external.js
@@ -3,6 +3,23 @@ const { RULE_NO_EXTERNAL } = require("../constants/settings");
 const { meta, dependencyLocation, getContextInfo, checkOptions } = require("../helpers/rules");
 const { getDependencyInfo, isNotRecognizedOrIgnored } = require("../helpers/elements");
 
+const forbiddenSpecifiers = (forbiddenSpecifierNames, specifiers) => {
+  if (!forbiddenSpecifierNames) {
+    return [];
+  }
+  const importedSpecifiersNames = specifiers
+    .filter((specifier) => {
+      return specifier.type === "ImportSpecifier" && specifier.imported.name;
+    })
+    .map((specifier) => specifier.imported.name);
+  return forbiddenSpecifierNames.reduce((forbiddenFound, forbiddenSpecifier) => {
+    if (importedSpecifiersNames.includes(forbiddenSpecifier)) {
+      forbiddenFound.push(forbiddenSpecifier);
+    }
+    return forbiddenFound;
+  }, []);
+};
+
 module.exports = {
   ...meta(`Enforce elements of one type to not use some external dependencies`, PLUGIN_NAME, [
     {
@@ -23,23 +40,54 @@ module.exports = {
     }
     checkOptions(context, "forbid", RULE_NO_EXTERNAL);
     const forbidOptions = (context.options[0] && context.options[0].forbid) || {};
+    const currentElementOptions = forbidOptions[currentElementInfo.type];
+    const currentElementDestructuredOptions = {};
+
+    if (currentElementOptions) {
+      currentElementOptions.forEach((forbid) => {
+        const libraryNameAsKey = Object.keys(forbid)[0];
+        if (
+          typeof forbid !== "string" &&
+          libraryNameAsKey &&
+          Array.isArray(forbid[libraryNameAsKey])
+        ) {
+          currentElementDestructuredOptions[libraryNameAsKey] = forbid[libraryNameAsKey];
+        }
+      });
+    }
 
     return {
       ImportDeclaration: (node) => {
         const dependencyInfo = getDependencyInfo(fileName, node.source.value, context.settings);
-        const currentElementOptions = forbidOptions[currentElementInfo.type];
 
-        if (
-          !dependencyInfo.isLocal &&
-          currentElementOptions &&
-          currentElementOptions.includes(dependencyInfo.name)
-        ) {
-          context.report({
-            message: `Usage of external module '${dependencyInfo.name}' is not allowed in '${currentElementInfo.type}'`,
-            type: PLUGIN_NAME,
-            node: node,
-            ...dependencyLocation(node, context),
-          });
+        if (!dependencyInfo.isLocal && currentElementOptions) {
+          if (currentElementOptions.includes(dependencyInfo.name)) {
+            // library is not allowed
+            context.report({
+              message: `Usage of external module '${dependencyInfo.name}' is not allowed in '${currentElementInfo.type}'`,
+              type: PLUGIN_NAME,
+              node: node,
+              ...dependencyLocation(node, context),
+            });
+          } else {
+            const forbiddenSpecifiersFound = forbiddenSpecifiers(
+              currentElementDestructuredOptions[dependencyInfo.name],
+              node.source.parent.specifiers
+            );
+            if (forbiddenSpecifiersFound.length > 0) {
+              // specifier is not allowed
+              context.report({
+                message: `Usage of '${forbiddenSpecifiersFound.join(
+                  ", "
+                )}' from external module '${dependencyInfo.name}' is not allowed in '${
+                  currentElementInfo.type
+                }'`,
+                type: PLUGIN_NAME,
+                node: node,
+                ...dependencyLocation(node, context),
+              });
+            }
+          }
         }
       },
     };

--- a/src/rules/no-external.js
+++ b/src/rules/no-external.js
@@ -59,19 +59,20 @@ module.exports = {
     return {
       ImportDeclaration: (node) => {
         const dependencyInfo = getDependencyInfo(fileName, node.source.value, context.settings);
+        const cleanDependencyName = dependencyInfo.name.split("/")[0];
 
         if (!dependencyInfo.isLocal && currentElementOptions) {
-          if (currentElementOptions.includes(dependencyInfo.name)) {
+          if (currentElementOptions.includes(cleanDependencyName)) {
             // library is not allowed
             context.report({
-              message: `Usage of external module '${dependencyInfo.name}' is not allowed in '${currentElementInfo.type}'`,
+              message: `Usage of external module '${cleanDependencyName}' is not allowed in '${currentElementInfo.type}'`,
               type: PLUGIN_NAME,
               node: node,
               ...dependencyLocation(node, context),
             });
           } else {
             const forbiddenSpecifiersFound = forbiddenSpecifiers(
-              currentElementDestructuredOptions[dependencyInfo.name],
+              currentElementDestructuredOptions[cleanDependencyName],
               node.source.parent.specifiers
             );
             if (forbiddenSpecifiersFound.length > 0) {
@@ -79,7 +80,7 @@ module.exports = {
               context.report({
                 message: `Usage of '${forbiddenSpecifiersFound.join(
                   ", "
-                )}' from external module '${dependencyInfo.name}' is not allowed in '${
+                )}' from external module '${cleanDependencyName}' is not allowed in '${
                   currentElementInfo.type
                 }'`,
                 type: PLUGIN_NAME,

--- a/test/src/rules/no-external.spec.js
+++ b/test/src/rules/no-external.spec.js
@@ -21,7 +21,12 @@ const options = [
         },
       ],
       components: ["react-router-dom"],
-      modules: [],
+      modules: [
+        "material-ui",
+        {
+          "react-router-dom": ["Link"],
+        },
+      ],
     },
   },
 ];
@@ -55,7 +60,12 @@ ruleTester.run(RULE, rule, {
       code: "import { withRouter } from 'react-router-dom'",
       options,
     },
-    // TODO, really? If we are forbidding importing specifiers, should we allow importing all library?
+    // Modules can import react
+    {
+      filename: absoluteFilePath("src/modules/module-a/ModuleA.js"),
+      code: "import React from 'react'",
+      options,
+    },
     // Helpers can import foo-library
     {
       filename: absoluteFilePath("src/helpers/helper-a/HelperA.js"),
@@ -198,6 +208,18 @@ ruleTester.run(RULE, rule, {
       errors: [
         {
           message: destructuredErrorMessage("helpers", "Link, Router", "foo-library"),
+          type: "ImportDeclaration",
+        },
+      ],
+    },
+    // Modules can't import material-ui
+    {
+      filename: absoluteFilePath("src/modules/module-a/ModuleA.js"),
+      code: "import { Label } from 'material-ui/core'",
+      options,
+      errors: [
+        {
+          message: errorMessage("modules", "material-ui"),
           type: "ImportDeclaration",
         },
       ],


### PR DESCRIPTION
### Added
- feat(no-external): Allow forbid importing external libraries specifiers
- fix(no-external): Do not allow importing subfolders of forbidden external libraries

closes #9 