### PR TITLE
Include option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 ### Added
 ### Changed
+- feat(#132): Detect paths from any node_modules folder as external
 ### Fixed
 ### Removed
 ### BREAKING CHANGES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 ### Added
+- feat(#131): Add `boundaries/include` option allowing to ignore all by default except files matching the pattern.
 ### Changed
-- feat(#132): Detect paths from any node_modules folder as external
+- feat(#132): Detect paths from any `node_modules` folder as external
 ### Fixed
 ### Removed
 ### BREAKING CHANGES

--- a/README.md
+++ b/README.md
@@ -200,6 +200,17 @@ Define patterns to recognize each file in the project as one of this element typ
 
 > Tip: You can enable the [debug mode](debug-mode) when configuring the plugin, and you will get information about the type assigned to each file in the project.
 
+#### __`boundaries/include`__
+
+Files or dependencies not matching these [`micromatch` patterns](https://github.com/micromatch/micromatch) will be ignored by the plugin. If this option is not provided, all files will be included.
+
+```json
+{
+  "settings": {
+    "boundaries/include": ["src/**/*.js"]
+  }
+}
+```
 
 #### __`boundaries/ignore`__
 
@@ -212,6 +223,8 @@ Files or dependencies matching these [`micromatch` patterns](https://github.com/
   }
 }
 ```
+
+> Note: The `boundaries/include` option has preference over `boundaries/ignore`. If you define `boundaries/include`, use `boundaries/ignore` to ignore subsets of included files.
 
 ### Predefined configurations
 

--- a/docs/rules/no-ignored.md
+++ b/docs/rules/no-ignored.md
@@ -4,7 +4,7 @@
 
 ## Rule details
 
-It checks `import` statements to local files. If the imported file is marked as ignored in the plugin settings, the `import` will be notified as an error.
+It checks `import` statements to local files. If the imported file is marked as ignored in the plugin settings, the `import` will be notified as an error in files recognized as "elements".
 
 ### Options
 
@@ -44,6 +44,7 @@ src/
 ```jsonc
 {
   "settings": {
+    "boundaries/include": ["src/**/*.js"],
     "boundaries/ignore": ["src/foo.js"],
     "boundaries/elements": [
       {
@@ -59,7 +60,7 @@ src/
 
 ### Examples of **incorrect** code for this rule:
 
-_`index.js` file is ignored, so it can't be imported by helpers_
+_`foo.js` file is ignored, so it can't be imported by helpers_
 
 ```js
 // src/helpers/data/sort.js
@@ -68,7 +69,7 @@ import foo from "../../foo"
 
 ### Examples of **correct** code for this rule:
 
-_`index.js` file is not recognized as any element, so it can import `foo.js`_
+_`index.js` file is not recognized as any known element type, so it can import `foo.js`_
 
 ```js
 // src/index.js
@@ -78,4 +79,3 @@ import foo from "./foo"
 ## Further reading
 
 Read [how to configure the `boundaries/elements` setting](../../README.md#global-settings) to assign an element type to each project's file.
-

--- a/src/constants/settings.js
+++ b/src/constants/settings.js
@@ -14,6 +14,7 @@ module.exports = {
   // settings
   ELEMENTS: `${PLUGIN_NAME}/elements`,
   IGNORE: `${PLUGIN_NAME}/ignore`,
+  INCLUDE: `${PLUGIN_NAME}/include`,
 
   // rules
   RULE_ELEMENT_TYPES: `${PLUGIN_NAME}/${ELEMENT_TYPES}`,

--- a/src/core/elementsInfo.js
+++ b/src/core/elementsInfo.js
@@ -2,7 +2,7 @@ const isCoreModule = require("is-core-module");
 const micromatch = require("micromatch");
 const resolve = require("eslint-module-utils/resolve").default;
 
-const { IGNORE, VALID_MODES } = require("../constants/settings");
+const { IGNORE, INCLUDE, VALID_MODES } = require("../constants/settings");
 const { getElements } = require("../helpers/settings");
 const { debugFileInfo } = require("../helpers/debug");
 
@@ -18,8 +18,21 @@ function baseModule(name, path) {
   return pkg;
 }
 
+function matchesIgnoreSetting(path, settings) {
+  return micromatch.isMatch(path, settings[IGNORE] || []);
+}
+
 function isIgnored(path, settings) {
-  return !path || micromatch.isMatch(path, settings[IGNORE] || []);
+  if (!path) {
+    return true;
+  }
+  if (settings[INCLUDE]) {
+    if (micromatch.isMatch(path, settings[INCLUDE])) {
+      return matchesIgnoreSetting(path, settings);
+    }
+    return true;
+  }
+  return matchesIgnoreSetting(path, settings);
 }
 
 function isBuiltIn(name, path) {

--- a/src/core/elementsInfo.js
+++ b/src/core/elementsInfo.js
@@ -34,9 +34,10 @@ function isScoped(name) {
 }
 
 const externalModuleRegExp = /^\w/;
+
 function isExternal(name, path) {
   return (
-    (!path || (!!path && path.indexOf("node_modules") === 0)) &&
+    (!path || (!!path && path.includes("node_modules"))) &&
     (externalModuleRegExp.test(name) || isScoped(name))
   );
 }


### PR DESCRIPTION
### Added
- feat(#131): Add `boundaries/include` option allowing to ignore all by default except files matching the pattern.

### Changed
- feat(#132): Detect paths from any `node_modules` folder as external