### PR TITLE
Release 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 ### BREAKING CHANGES
 
+## [2.4.1] - 2021-08-16
+
+### Fixed
+- fix: Remove trace when ESLINT_PLUGIN_BOUNDARIES_DEBUG is not set
+
 ## [2.4.0] - 2021-08-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 ### Added
-- docs(#107): Add usage with TypeScript docs
 ### Changed
-- chore(deps): Update devDependencies
 ### Fixed
 ### Removed
 ### BREAKING CHANGES
+
+## [2.4.2] - 2021-08-22
+
+### Added
+- docs(#107): Add usage with TypeScript docs
+
+### Changed
+- chore(deps): Update devDependencies
+
 
 ## [2.4.1] - 2021-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 ### BREAKING CHANGES
 
-## [unreleased] - 2021-11-01
+## [2.5.0] - 2021-11-01
 ### Changed
 - chore(deps): Update devDependencies
 - chore(deps): Support any NodeJs version greater than 12.x. Run tests also with NodeJS 17. Use NodeJS 16 in publish pipelines

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 ### BREAKING CHANGES
 
+## [2.4.0] - 2021-08-15
+
+### Added
+- feat: Improve performance adding internal cache
+
+### Changed
+- chore(deps): Update devDependencies
+
 ## [2.3.0] - 2021-07-20
 
 ### Added

--- a/jest.config.js
+++ b/jest.config.js
@@ -23,8 +23,8 @@ module.exports = {
       statements: 100,
     },
     // Ignore coverage of debugger
-    "./src/core/cache.js": {
-      branches: 83,
+    "./src/helpers/debug.js": {
+      branches: 91,
     },
     // Decrease coverage due to cache branches
     "./src/core/elementsInfo.js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-boundaries",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-boundaries",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-boundaries",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-boundaries",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-boundaries",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Eslint plugin checking architecture boundaries between elements",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-boundaries",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "description": "Eslint plugin checking architecture boundaries between elements",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-boundaries",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Eslint plugin checking architecture boundaries between elements",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-boundaries",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "description": "Eslint plugin checking architecture boundaries between elements",
   "keywords": [
     "eslint",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=javierbrea
 sonar.projectKey=javierbrea_eslint-plugin-boundaries
-sonar.projectVersion=2.3.0
+sonar.projectVersion=2.4.0
 
 sonar.javascript.file.suffixes=.js
 sonar.sourceEncoding=UTF-8

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=javierbrea
 sonar.projectKey=javierbrea_eslint-plugin-boundaries
-sonar.projectVersion=2.4.2
+sonar.projectVersion=2.5.0
 
 sonar.javascript.file.suffixes=.js
 sonar.sourceEncoding=UTF-8

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=javierbrea
 sonar.projectKey=javierbrea_eslint-plugin-boundaries
-sonar.projectVersion=2.4.0
+sonar.projectVersion=2.4.1
 
 sonar.javascript.file.suffixes=.js
 sonar.sourceEncoding=UTF-8

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=javierbrea
 sonar.projectKey=javierbrea_eslint-plugin-boundaries
-sonar.projectVersion=2.4.1
+sonar.projectVersion=2.4.2
 
 sonar.javascript.file.suffixes=.js
 sonar.sourceEncoding=UTF-8

--- a/src/core/cache.js
+++ b/src/core/cache.js
@@ -13,9 +13,7 @@ class Cache {
 
   load(key) {
     if (this._cache[key]) {
-      if (process.env.ESLINT_PLUGIN_BOUNDARIES_DEBUG) {
-        debug(`Returning "${key}" ${this._name} info from cache`);
-      }
+      debug(`Returning "${key}" ${this._name} info from cache`);
       return this._cache[key];
     }
 

--- a/src/helpers/debug.js
+++ b/src/helpers/debug.js
@@ -14,7 +14,9 @@ function warn(message) {
 }
 
 function debug(message) {
-  trace(message, "grey");
+  if (process.env.ESLINT_PLUGIN_BOUNDARIES_DEBUG) {
+    trace(message, "grey");
+  }
 }
 
 function success(message) {


### PR DESCRIPTION
### Changed
- chore(deps): Update devDependencies
- chore(deps): Support any NodeJs version greater than 12.x. Run tests also with NodeJS 17. Use NodeJS 16 in publish pipelines. closes #157 