### PR TITLE
Custom error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - fix: Support array of micromatch patterns when replacing captured values
+- docs: Fix broken links
 
 ### Removed
 - feat: Remove cache traces from debug mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - feat(#87): Support custom messages in `element-types` config
 
 ### Changed
-- feat(#87): Add context about the specific rule forbidding the import to the `element-types` error message
+- feat(#87): Add context about the specific rule forbidding the import to the `element-types` error message. Add information about file and dependency when import is forbidden due to the default configuration.
 - refactor: Add isArray and isString utils
 
 ### Fixed
 - fix: Support array of micromatch patterns when replacing captured values
+
+### Removed
+- feat: Remove cache traces from debug mode
 
 ## [2.5.1] - 2021-11-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - feat(#87): Add context about the specific rule forbidding the import to the `element-types` error message. Add information about file and dependency when import is forbidden due to the default configuration.
 - refactor: Add isArray and isString utils
+- chore(deps): Support any eslint version greater than 6.x in peerDependencies
 
 ### Fixed
 - fix: Support array of micromatch patterns when replacing captured values

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+### Added
+- feat(#87): Support custom messages in `element-types` config
+
 ### Changed
 - feat(#87): Add context about the specific rule forbidding the import to the `element-types` error message
 - refactor: Add isArray and isString utils

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 ### BREAKING CHANGES
 
-## [unreleased] - 2021-11-06
+## [2.5.1] - 2021-11-06
 
 ### Fixed
 - docs(#160): Fix links to debug mode section
 - fix(#133): Remove plugin namespace from rules documentation links
 - fix(#133): no-private rule had undefined name
+
+### Removed
+- docs: Remove npm dependencies badge because david-dm site is down
 
 ## [2.5.0] - 2021-11-01
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 ### BREAKING CHANGES
 
+## [unreleased]
+
+### Changed
+- feat(#87): Add context about the specific rule forbidding the import to the `element-types` error message
+- refactor: Add isArray and isString utils
+
+### Fixed
+- fix: Support array of micromatch patterns when replacing captured values
+
 ## [2.5.1] - 2021-11-06
 
 ### Fixed

--- a/docs/rules/element-types.md
+++ b/docs/rules/element-types.md
@@ -14,10 +14,12 @@ It checks `import` statements between the element types of the project based on 
 
 * `enabled`: for enabling the rule. 0=off, 1=warn, 2=error.
 * `default`: `allow` or `disallow`. If no one `rule` matches, the dependency will be allowed or disallowed based on this value.
-* `rules`: Rules to be processed in order to decide if the `import` statement has to be allowed or not.
+* `message`: Custom message for the rule errors. Note that __the rule default message provides a lot of information about why the error was produced__, so you should define a custom message only if you are sure about what you are doing. Read ["error messages"]("#error-messages") for further information.
+* `rules`: Rules to be processed in order to decide if the `import` statement has to be allowed or not. It must be an array of objects containing:
   * `from`: `<element matchers>` If the file being analyzed matches with this, then the rule will be executed to know if it allows/disallows the `import`. If not, the rule is skipped.
   * `disallow`: `<element matchers>` If the element being imported matches with this, then the result of the rule will be "disallow", and the import will be notified as an `eslint` error (this value can be overwritten by a next rule returning "allow")
   * `allow`: `<element matchers>` If the element being imported matches with this, then the result of the rule will be "allow", and the import will not be notified as an `eslint` error (this value can be overwritten by a next rule returning "disallow")
+  * `message`: `<string>` Custom error message only for this rule. Read ["error messages"](../../README.md#error-messages) for further info.
 
 ##### Further reading:
 * [Main format of rules options](../../README.md#main-format-of-rules-options)
@@ -78,6 +80,15 @@ So, if the `from` element has captured values `{ family: "atom", elementName: "c
   }
 }
 ```
+
+### Error messages
+
+This rule provides a lot of information about the specific option producing an error, so the user can have enough context to solve it.
+
+* If the error is produced because all imports are disallowed by default, and no rule is specificly allowing it, then the message provides information about the file and the dependency types and captured values: `No rule allowing this dependency was found. File is of type 'components' with category 'molecules' and elementName 'molecule-c'. Dependency is of type 'modules' with domain 'domain-a' and elementName 'module-a'`.
+* If the error is produced by a specific option, the the message includes information about the option producing it: `Importing elements of type 'components' with category 'atoms' and elementName '*-a' is not allowed in elements of type 'helpers' with elementName 'helper-c'. Disallowed in rule 1`
+
+Anyway, you can configure a custom error message for changing this behaviour, or even custom error messages only for a specific rule option. Read ["error messages"](../../README.md#error-messages) for further info about how to configure messages.
 
 ### Settings
 

--- a/docs/rules/element-types.md
+++ b/docs/rules/element-types.md
@@ -14,7 +14,7 @@ It checks `import` statements between the element types of the project based on 
 
 * `enabled`: for enabling the rule. 0=off, 1=warn, 2=error.
 * `default`: `allow` or `disallow`. If no one `rule` matches, the dependency will be allowed or disallowed based on this value.
-* `message`: Custom message for the rule errors. Note that __the rule default message provides a lot of information about why the error was produced__, so you should define a custom message only if you are sure about what you are doing. Read ["error messages"]("#error-messages") for further information.
+* `message`: Custom message for the rule errors. Note that __the rule default message provides a lot of information about why the error was produced__, so you should define a custom message only if you are sure about what you are doing. Read ["error messages"](#error-messages) for further information.
 * `rules`: Rules to be processed in order to decide if the `import` statement has to be allowed or not. It must be an array of objects containing:
   * `from`: `<element matchers>` If the file being analyzed matches with this, then the rule will be executed to know if it allows/disallows the `import`. If not, the rule is skipped.
   * `disallow`: `<element matchers>` If the element being imported matches with this, then the result of the rule will be "disallow", and the import will be notified as an `eslint` error (this value can be overwritten by a next rule returning "allow")
@@ -23,7 +23,7 @@ It checks `import` statements between the element types of the project based on 
 
 ##### Further reading:
 * [Main format of rules options](../../README.md#main-format-of-rules-options)
-* [Element matchers](../../README.md#element-matchers)
+* [Element matchers](../../README.md#elements-matchers)
 
 ##### Comparing captures of the file element with captures of the imported element
 

--- a/docs/rules/entry-point.md
+++ b/docs/rules/entry-point.md
@@ -21,7 +21,7 @@ It checks `import` statements to the elements of the project and ensure that eac
 
 ##### Further reading:
 * [Main format of rules options](../../README.md#main-format-of-rules-options)
-* [Element matchers](../../README.md#element-matchers)
+* [Element matchers](../../README.md#elements-matchers)
 
 ##### Options example
 

--- a/docs/rules/external.md
+++ b/docs/rules/external.md
@@ -51,7 +51,7 @@ __Examples__
 
 ##### Further reading:
 * [Main format of rules options](../../README.md#main-format-of-rules-options)
-* [Element matchers](../../README.md#element-matchers)
+* [Element matchers](../../README.md#elements-matchers)
 
 ##### Options example
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -38,5 +38,5 @@ module.exports = {
 
   // The glob patterns Jest uses to detect test files
   testMatch: ["<rootDir>/test/**/*.spec.js"],
-  // testMatch: ["<rootDir>/test/**/one-level/element-types.spec.js"],
+  // testMatch: ["<rootDir>/test/**/two-levels/element-types.spec.js"],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -38,5 +38,5 @@ module.exports = {
 
   // The glob patterns Jest uses to detect test files
   testMatch: ["<rootDir>/test/**/*.spec.js"],
-  // testMatch: ["<rootDir>/test/**/two-levels/element-types.spec.js"],
+  // testMatch: ["<rootDir>/test/**/one-level/element-types.spec.js"],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -38,5 +38,5 @@ module.exports = {
 
   // The glob patterns Jest uses to detect test files
   testMatch: ["<rootDir>/test/**/*.spec.js"],
-  // testMatch: ["<rootDir>/test/**/base-pattern/*.spec.js"],
+  // testMatch: ["<rootDir>/test/**/two-levels/element-types.spec.js"],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -24,7 +24,7 @@ module.exports = {
     },
     // Ignore coverage of debugger
     "./src/helpers/debug.js": {
-      branches: 91,
+      branches: 83,
     },
     // Decrease coverage due to cache branches
     "./src/core/elementsInfo.js": {
@@ -38,5 +38,5 @@ module.exports = {
 
   // The glob patterns Jest uses to detect test files
   testMatch: ["<rootDir>/test/**/*.spec.js"],
-  // testMatch: ["<rootDir>/test/**/two-levels/element-types.spec.js"],
+  // testMatch: ["<rootDir>/test/**/nestjs-example/element-types.spec.js"],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-boundaries",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-boundaries",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Eslint plugin checking architecture boundaries between elements",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "prepare": "is-ci || husky install"
   },
   "peerDependencies": {
-    "eslint": "6.x || 7.x || 8.x"
+    "eslint": ">=6.0.0"
   },
   "dependencies": {
     "eslint-import-resolver-node": "0.3.6",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=javierbrea
 sonar.projectKey=javierbrea_eslint-plugin-boundaries
-sonar.projectVersion=2.5.0
+sonar.projectVersion=2.5.1
 
 sonar.javascript.file.suffixes=.js
 sonar.sourceEncoding=UTF-8

--- a/src/core/cache.js
+++ b/src/core/cache.js
@@ -11,7 +11,6 @@ class Cache {
 
   load(key) {
     if (this._cache[key]) {
-      // debug(`Returning "${key}" ${this._name} info from cache`);
       return this._cache[key];
     }
 
@@ -30,7 +29,6 @@ class CachesManager {
       return cacheCandidate._settings === settings;
     });
     if (!cache) {
-      // debug(`${this._name} cache not found, creating new`);
       cache = new Cache(this._name, settings);
       this._caches.push(cache);
     }

--- a/src/core/cache.js
+++ b/src/core/cache.js
@@ -1,5 +1,3 @@
-const { debug } = require("../helpers/debug");
-
 class Cache {
   constructor(name, settings) {
     this._cache = {};
@@ -13,7 +11,7 @@ class Cache {
 
   load(key) {
     if (this._cache[key]) {
-      debug(`Returning "${key}" ${this._name} info from cache`);
+      // debug(`Returning "${key}" ${this._name} info from cache`);
       return this._cache[key];
     }
 
@@ -32,7 +30,7 @@ class CachesManager {
       return cacheCandidate._settings === settings;
     });
     if (!cache) {
-      debug(`${this._name} cache not found, creating new`);
+      // debug(`${this._name} cache not found, creating new`);
       cache = new Cache(this._name, settings);
       this._caches.push(cache);
     }

--- a/src/core/elementsInfo.js
+++ b/src/core/elementsInfo.js
@@ -5,6 +5,7 @@ const resolve = require("eslint-module-utils/resolve").default;
 const { IGNORE, INCLUDE, VALID_MODES } = require("../constants/settings");
 const { getElements } = require("../helpers/settings");
 const { debugFileInfo } = require("../helpers/debug");
+const { isArray } = require("../helpers/utils");
 
 const { filesCache, importsCache, elementsCache } = require("./cache");
 
@@ -112,9 +113,7 @@ function elementTypeAndParents(path, settings) {
         let elementFound = false;
         getElements(settings).forEach((element) => {
           const typeOfMatch = VALID_MODES.includes(element.mode) ? element.mode : VALID_MODES[0];
-          const elementPatterns = Array.isArray(element.pattern)
-            ? element.pattern
-            : [element.pattern];
+          const elementPatterns = isArray(element.pattern) ? element.pattern : [element.pattern];
           elementPatterns.forEach((elementPattern) => {
             if (!elementFound) {
               const useFullPathMatch = typeOfMatch === VALID_MODES[2] && !elementResult.type;

--- a/src/helpers/messages.js
+++ b/src/helpers/messages.js
@@ -14,9 +14,6 @@ function micromatchPatternMessage(micromatchPatterns, elementCapturedValues) {
     micromatchPatterns,
     elementCapturedValues
   );
-  if (isString(micromatchPatternsWithValues)) {
-    return quote(micromatchPatternsWithValues);
-  }
   if (isArray(micromatchPatternsWithValues)) {
     if (micromatchPatternsWithValues.length === 1) {
       return quote(micromatchPatternsWithValues[0]);
@@ -31,6 +28,7 @@ function micromatchPatternMessage(micromatchPatterns, elementCapturedValues) {
       return `${message}, ${quote(micromatchPattern)}`;
     }, "");
   }
+  return quote(micromatchPatternsWithValues);
 }
 
 function capturedValuesMatcherMessage(capturedValuesPattern, elementCapturedValues) {
@@ -62,9 +60,6 @@ function elementMatcherMessage(elementMatcher, elementCapturedValues) {
 }
 
 function ruleElementMessage(elementPatterns, elementCapturedValues) {
-  if (isString(elementPatterns)) {
-    return elementMatcherMessage(elementPatterns, elementCapturedValues);
-  }
   if (isArray(elementPatterns)) {
     if (elementPatterns.length === 1) {
       return elementMatcherMessage(elementPatterns[0], elementCapturedValues);
@@ -76,6 +71,7 @@ function ruleElementMessage(elementPatterns, elementCapturedValues) {
       return `${message}, or ${elementMatcherMessage(elementPattern, elementCapturedValues)}`;
     }, "");
   }
+  return elementMatcherMessage(elementPatterns, elementCapturedValues);
 }
 
 function customErrorMessage(message, file, dependency) {

--- a/src/helpers/messages.js
+++ b/src/helpers/messages.js
@@ -1,0 +1,84 @@
+const { isString, isArray } = require("./utils");
+const { micromatchPatternReplacingObjectValues } = require("./rules");
+
+function quote(str) {
+  return `'${str}'`;
+}
+
+function typeMessage(elementMatcher) {
+  return `elements of type ${quote(elementMatcher)}`;
+}
+
+function micromatchPatternMessage(micromatchPatterns, elementCapturedValues) {
+  const micromatchPatternsWithValues = micromatchPatternReplacingObjectValues(
+    micromatchPatterns,
+    elementCapturedValues
+  );
+  if (isString(micromatchPatternsWithValues)) {
+    return quote(micromatchPatternsWithValues);
+  }
+  if (isArray(micromatchPatternsWithValues)) {
+    if (micromatchPatternsWithValues.length === 1) {
+      return quote(micromatchPatternsWithValues[0]);
+    }
+    return micromatchPatternsWithValues.reduce((message, micromatchPattern, index) => {
+      if (index === 0) {
+        return quote(micromatchPattern);
+      }
+      if (index === micromatchPatternsWithValues.length - 1) {
+        return `${message} or ${quote(micromatchPattern)}`;
+      }
+      return `${message}, ${quote(micromatchPattern)}`;
+    }, "");
+  }
+}
+
+function capturedValuesMatcherMessage(capturedValuesPattern, elementCapturedValues) {
+  const capturedValuesPatternKeys = Object.keys(capturedValuesPattern);
+  return capturedValuesPatternKeys
+    .map((key) => {
+      return [key, capturedValuesPattern[key]];
+    })
+    .reduce((message, propertyNameAndMatcher, index) => {
+      const concater =
+        capturedValuesPatternKeys.length > 1 && index === capturedValuesPatternKeys.length - 1
+          ? " and"
+          : " with";
+      return `${message}${concater} ${propertyNameAndMatcher[0]} ${micromatchPatternMessage(
+        propertyNameAndMatcher[1],
+        elementCapturedValues
+      )}`;
+    }, "");
+}
+
+function elementMatcherMessage(elementMatcher, elementCapturedValues) {
+  if (isString(elementMatcher)) {
+    return typeMessage(elementMatcher);
+  }
+  return `${typeMessage(elementMatcher[0])}${capturedValuesMatcherMessage(
+    elementMatcher[1],
+    elementCapturedValues
+  )}`;
+}
+
+function ruleElementMessage(elementPatterns, elementCapturedValues) {
+  if (isString(elementPatterns)) {
+    return elementMatcherMessage(elementPatterns, elementCapturedValues);
+  }
+  if (isArray(elementPatterns)) {
+    if (elementPatterns.length === 1) {
+      return elementMatcherMessage(elementPatterns[0], elementCapturedValues);
+    }
+    return elementPatterns.reduce((message, elementPattern, index) => {
+      if (index === 0) {
+        return elementMatcherMessage(elementPattern, elementCapturedValues);
+      }
+      return `${message}, or ${elementMatcherMessage(elementPattern, elementCapturedValues)}`;
+    }, "");
+  }
+}
+
+module.exports = {
+  quote,
+  ruleElementMessage,
+};

--- a/src/helpers/messages.js
+++ b/src/helpers/messages.js
@@ -1,4 +1,4 @@
-const { isString, isArray } = require("./utils");
+const { isString, isArray, replaceObjectValuesInTemplates } = require("./utils");
 const { micromatchPatternReplacingObjectValues } = require("./rules");
 
 function quote(str) {
@@ -78,7 +78,16 @@ function ruleElementMessage(elementPatterns, elementCapturedValues) {
   }
 }
 
+function customErrorMessage(message, file, dependency) {
+  return replaceObjectValuesInTemplates(
+    replaceObjectValuesInTemplates(message, { ...file.capturedValues, type: file.type }, "file"),
+    { ...dependency.capturedValues, type: dependency.type },
+    "dependency"
+  );
+}
+
 module.exports = {
   quote,
   ruleElementMessage,
+  customErrorMessage,
 };

--- a/src/helpers/messages.js
+++ b/src/helpers/messages.js
@@ -9,6 +9,16 @@ function typeMessage(elementMatcher) {
   return `elements of type ${quote(elementMatcher)}`;
 }
 
+function propertiesConcater(properties, index) {
+  if (properties.length > 1 && index === properties.length - 1) {
+    return " and";
+  }
+  if (index === 0) {
+    return " with";
+  }
+  return ",";
+}
+
 function micromatchPatternMessage(micromatchPatterns, elementCapturedValues) {
   const micromatchPatternsWithValues = micromatchPatternReplacingObjectValues(
     micromatchPatterns,
@@ -38,14 +48,9 @@ function capturedValuesMatcherMessage(capturedValuesPattern, elementCapturedValu
       return [key, capturedValuesPattern[key]];
     })
     .reduce((message, propertyNameAndMatcher, index) => {
-      const concater =
-        capturedValuesPatternKeys.length > 1 && index === capturedValuesPatternKeys.length - 1
-          ? " and"
-          : " with";
-      return `${message}${concater} ${propertyNameAndMatcher[0]} ${micromatchPatternMessage(
-        propertyNameAndMatcher[1],
-        elementCapturedValues
-      )}`;
+      return `${message}${propertiesConcater(capturedValuesPatternKeys, index)} ${
+        propertyNameAndMatcher[0]
+      } ${micromatchPatternMessage(propertyNameAndMatcher[1], elementCapturedValues)}`;
     }, "");
 }
 
@@ -82,8 +87,31 @@ function customErrorMessage(message, file, dependency) {
   );
 }
 
+function elementCapturedValuesMessage(capturedValues) {
+  if (!capturedValues) {
+    return "";
+  }
+  const capturedValuesKeys = Object.keys(capturedValues);
+  return capturedValuesKeys
+    .map((key) => {
+      return [key, capturedValues[key]];
+    })
+    .reduce((message, propertyNameAndValue, index) => {
+      return `${message}${propertiesConcater(capturedValuesKeys, index)} ${
+        propertyNameAndValue[0]
+      } ${quote(propertyNameAndValue[1])}`;
+    }, "");
+}
+
+function elementMessage(elementInfo) {
+  return `of type ${quote(elementInfo.type)}${elementCapturedValuesMessage(
+    elementInfo.capturedValues
+  )}`;
+}
+
 module.exports = {
   quote,
   ruleElementMessage,
   customErrorMessage,
+  elementMessage,
 };

--- a/src/helpers/rules.js
+++ b/src/helpers/rules.js
@@ -1,6 +1,6 @@
 const micromatch = require("micromatch");
 
-const { isArray } = require("./utils");
+const { isArray, replaceObjectValuesInTemplates } = require("./utils");
 
 const REPO_URL = "https://github.com/javierbrea/eslint-plugin-boundaries";
 
@@ -44,20 +44,8 @@ function dependencyLocation(node, context) {
   };
 }
 
-function replaceObjectValueInMicromatchPattern(micromatchPattern, key, value) {
-  return micromatchPattern.replace(`\${${key}}`, value);
-}
-
 function micromatchPatternReplacingObjectValues(pattern, object) {
-  return Object.keys(object).reduce((result, objectKey) => {
-    // If micromatch pattern is an array, replace key by value in all patterns
-    if (isArray(result)) {
-      return result.map((resultEntry) => {
-        return replaceObjectValueInMicromatchPattern(resultEntry, objectKey, object[objectKey]);
-      });
-    }
-    return replaceObjectValueInMicromatchPattern(result, objectKey, object[objectKey]);
-  }, pattern);
+  return replaceObjectValuesInTemplates(pattern, object);
 }
 
 function isObjectMatch(objectWithMatchers, object, objectWithValuesToReplace) {
@@ -153,6 +141,7 @@ function elementRulesAllowDependency({
               element: rule[rulesMainKey(mainKey)],
               disallow: rule.disallow,
               index: rule.index,
+              message: rule.message,
             },
           ];
         }
@@ -170,6 +159,7 @@ function elementRulesAllowDependency({
       null,
       {
         isDefault: true,
+        message: options.message,
       },
     ]
   );

--- a/src/helpers/rules.js
+++ b/src/helpers/rules.js
@@ -141,7 +141,7 @@ function elementRulesAllowDependency({
               element: rule[rulesMainKey(mainKey)],
               disallow: rule.disallow,
               index: rule.index,
-              message: rule.message,
+              message: rule.message || options.message,
             },
           ];
         }

--- a/src/helpers/settings.js
+++ b/src/helpers/settings.js
@@ -1,7 +1,8 @@
 const { TYPES, ELEMENTS, VALID_MODES } = require("../constants/settings");
+const { isString } = require("./utils");
 
 function isLegacyType(type) {
-  return typeof type === "string";
+  return isString(type);
 }
 
 // TODO, remove in next major version

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -1,0 +1,12 @@
+function isString(object) {
+  return typeof object === "string";
+}
+
+function isArray(object) {
+  return Array.isArray(object);
+}
+
+module.exports = {
+  isString,
+  isArray,
+};

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -6,7 +6,25 @@ function isArray(object) {
   return Array.isArray(object);
 }
 
+function replaceObjectValueInTemplate(template, key, value, namespace) {
+  const keyToReplace = namespace ? `${namespace}.${key}` : key;
+  return template.replace(`\${${keyToReplace}}`, value);
+}
+
+function replaceObjectValuesInTemplates(strings, object, namespace) {
+  return Object.keys(object).reduce((result, objectKey) => {
+    // If template is an array, replace key by value in all patterns
+    if (isArray(result)) {
+      return result.map((resultEntry) => {
+        return replaceObjectValueInTemplate(resultEntry, objectKey, object[objectKey], namespace);
+      });
+    }
+    return replaceObjectValueInTemplate(result, objectKey, object[objectKey], namespace);
+  }, strings);
+}
+
 module.exports = {
   isString,
   isArray,
+  replaceObjectValuesInTemplates,
 };

--- a/src/helpers/validations.js
+++ b/src/helpers/validations.js
@@ -5,7 +5,7 @@ const { TYPES, ALIAS, ELEMENTS, VALID_MODES } = require("../constants/settings")
 const { getElementsTypeNames, isLegacyType } = require("./settings");
 const { rulesMainKey } = require("./rules");
 const { warnOnce } = require("./debug");
-const { isArray } = require("./utils");
+const { isArray, isString } = require("./utils");
 
 const invalidMatchers = [];
 
@@ -118,7 +118,7 @@ function validateElements(elements) {
       );
     } else {
       Object.keys(element).forEach(() => {
-        if (!element.type || typeof element.type !== "string") {
+        if (!element.type || !isString(element.type)) {
           warnOnce(`Please provide type in '${ELEMENTS}' setting`);
         }
         if (element.mode && !VALID_MODES.includes(element.mode)) {
@@ -128,10 +128,7 @@ function validateElements(elements) {
             )}. Default value "${VALID_MODES[0]}" will be used instead`
           );
         }
-        if (
-          !element.pattern ||
-          !(typeof element.pattern === "string" || isArray(element.pattern))
-        ) {
+        if (!element.pattern || !(isString(element.pattern) || isArray(element.pattern))) {
           warnOnce(`Please provide a valid pattern in '${ELEMENTS}' setting`);
         }
         if (element.capture && !isArray(element.capture)) {

--- a/src/helpers/validations.js
+++ b/src/helpers/validations.js
@@ -5,6 +5,7 @@ const { TYPES, ALIAS, ELEMENTS, VALID_MODES } = require("../constants/settings")
 const { getElementsTypeNames, isLegacyType } = require("./settings");
 const { rulesMainKey } = require("./rules");
 const { warnOnce } = require("./debug");
+const { isArray } = require("./utils");
 
 const invalidMatchers = [];
 
@@ -81,12 +82,12 @@ function rulesOptionsSchema(options = {}) {
 }
 
 function isValidElementTypesMatcher(matcher, settings) {
-  const mathcherToCheck = Array.isArray(matcher) ? matcher[0] : matcher;
+  const mathcherToCheck = isArray(matcher) ? matcher[0] : matcher;
   return !matcher || micromatch.some(getElementsTypeNames(settings), mathcherToCheck);
 }
 
 function validateElementTypesMatcher(elementsMatcher, settings) {
-  const [matcher] = Array.isArray(elementsMatcher) ? elementsMatcher : [elementsMatcher];
+  const [matcher] = isArray(elementsMatcher) ? elementsMatcher : [elementsMatcher];
   if (!invalidMatchers.includes(matcher) && !isValidElementTypesMatcher(matcher, settings)) {
     invalidMatchers.push(matcher);
     warnOnce(`Option '${matcher}' does not match any element type from '${ELEMENTS}' setting`);
@@ -94,7 +95,7 @@ function validateElementTypesMatcher(elementsMatcher, settings) {
 }
 
 function validateElements(elements) {
-  if (!elements || !Array.isArray(elements) || !elements.length) {
+  if (!elements || !isArray(elements) || !elements.length) {
     warnOnce(`Please provide element types using the '${ELEMENTS}' setting`);
     return;
   }
@@ -118,11 +119,11 @@ function validateElements(elements) {
         }
         if (
           !element.pattern ||
-          !(typeof element.pattern === "string" || Array.isArray(element.pattern))
+          !(typeof element.pattern === "string" || isArray(element.pattern))
         ) {
           warnOnce(`Please provide a valid pattern in '${ELEMENTS}' setting`);
         }
-        if (element.capture && !Array.isArray(element.capture)) {
+        if (element.capture && !isArray(element.capture)) {
           warnOnce(`Invalid capture property in '${ELEMENTS}' setting`);
         }
       });

--- a/src/helpers/validations.js
+++ b/src/helpers/validations.js
@@ -42,7 +42,7 @@ function elementsMatcherSchema(matcherOptions = DEFAULT_MATCHER_OPTIONS) {
   };
 }
 
-function rulesOptionsSchema(options = {}) {
+function rulesOptionsSchema(options) {
   const mainKey = rulesMainKey(options.rulesMainKey);
   const schema = [
     {

--- a/src/helpers/validations.js
+++ b/src/helpers/validations.js
@@ -44,7 +44,7 @@ function elementsMatcherSchema(matcherOptions = DEFAULT_MATCHER_OPTIONS) {
 
 function rulesOptionsSchema(options = {}) {
   const mainKey = rulesMainKey(options.rulesMainKey);
-  return [
+  const schema = [
     {
       type: "object",
       properties: {
@@ -79,6 +79,17 @@ function rulesOptionsSchema(options = {}) {
       additionalProperties: false,
     },
   ];
+  if (options.customMessage) {
+    schema[0].properties.message = {
+      type: "string",
+    };
+  }
+  if (options.customRuleMessage) {
+    schema[0].properties.rules.items.properties.message = {
+      type: "string",
+    };
+  }
+  return schema;
 }
 
 function isValidElementTypesMatcher(matcher, settings) {

--- a/src/rules/element-types.js
+++ b/src/rules/element-types.js
@@ -8,7 +8,7 @@ const {
   isMatchElementType,
   elementRulesAllowDependency,
 } = require("../helpers/rules");
-const { customErrorMessage, ruleElementMessage } = require("../helpers/messages");
+const { customErrorMessage, ruleElementMessage, elementMessage } = require("../helpers/messages");
 
 function elementRulesAllowDependencyType(element, dependency, options) {
   return elementRulesAllowDependency({
@@ -25,7 +25,9 @@ function errorMessage(ruleData, file, dependency) {
     return customErrorMessage(ruleReport.message, file, dependency);
   }
   if (ruleReport.isDefault) {
-    return "Importing elements is disallowed by default. No rule allowing this dependency was found";
+    return `No rule allowing this dependency was found. File is ${elementMessage(
+      file
+    )}. Dependency is ${elementMessage(dependency)}`;
   }
   return `Importing ${ruleElementMessage(
     ruleReport.disallow,

--- a/src/rules/element-types.js
+++ b/src/rules/element-types.js
@@ -29,7 +29,7 @@ function errorMessage(ruleData, file, dependency) {
   }
   return `Importing ${ruleElementMessage(
     ruleReport.disallow,
-    dependency.capturedValues
+    file.capturedValues
   )} is not allowed in ${ruleElementMessage(
     ruleReport.element,
     file.capturedValues

--- a/test/rules/base-pattern/element-types.spec.js
+++ b/test/rules/base-pattern/element-types.spec.js
@@ -1,6 +1,6 @@
 const { ELEMENT_TYPES: RULE } = require("../../../src/constants/rules");
 const { SETTINGS, createRuleTester, pathResolvers } = require("../../support/helpers");
-const { ELEMENT_TYPES_DEFAULT_MESSAGE } = require("../../support/messages");
+const { elementTypesNoRuleMessage } = require("../../support/messages");
 
 const rule = require(`../../../src/rules/${RULE}`);
 
@@ -138,7 +138,10 @@ ruleTester.run(RULE, rule, {
       options,
       errors: [
         {
-          message: ELEMENT_TYPES_DEFAULT_MESSAGE,
+          message: elementTypesNoRuleMessage({
+            file: "'modules' with parentFolders 'test/fixtures/base-pattern', domain 'domain-a' and elementName 'module-a'",
+            dep: "'modules' with parentFolders 'test/fixtures/base-pattern', domain 'domain-b' and elementName 'module-c'",
+          }),
           type: "ImportDeclaration",
         },
       ],
@@ -150,7 +153,10 @@ ruleTester.run(RULE, rule, {
       options,
       errors: [
         {
-          message: ELEMENT_TYPES_DEFAULT_MESSAGE,
+          message: elementTypesNoRuleMessage({
+            file: "'modules' with parentFolders 'test/fixtures/base-pattern', domain 'domain-a' and elementName 'module-h'",
+            dep: "'modules' with parentFolders 'test/fixtures/base-pattern', domain 'domain-b' and elementName 'module-c'",
+          }),
           type: "ImportDeclaration",
         },
       ],
@@ -162,7 +168,10 @@ ruleTester.run(RULE, rule, {
       options,
       errors: [
         {
-          message: ELEMENT_TYPES_DEFAULT_MESSAGE,
+          message: elementTypesNoRuleMessage({
+            file: "'modules' with parentFolders 'test/fixtures/base-pattern', domain 'domain-a' and elementName 'module-a'",
+            dep: "'components' with parentFolders 'test/fixtures/base-pattern', domain 'domain-b', type 'atoms' and elementName 'atom-c'",
+          }),
           type: "ImportDeclaration",
         },
       ],
@@ -174,7 +183,10 @@ ruleTester.run(RULE, rule, {
       options,
       errors: [
         {
-          message: ELEMENT_TYPES_DEFAULT_MESSAGE,
+          message: elementTypesNoRuleMessage({
+            file: "'components' with parentFolders 'test/fixtures/base-pattern', domain 'domain-a', type 'molecules' and elementName 'molecule-a'",
+            dep: "'modules' with parentFolders 'test/fixtures/base-pattern', domain 'domain-a' and elementName 'module-a'",
+          }),
           type: "ImportDeclaration",
         },
       ],
@@ -186,7 +198,10 @@ ruleTester.run(RULE, rule, {
       options,
       errors: [
         {
-          message: ELEMENT_TYPES_DEFAULT_MESSAGE,
+          message: elementTypesNoRuleMessage({
+            file: "'components' with parentFolders 'test/fixtures/base-pattern', domain 'domain-a', type 'molecules' and elementName 'molecule-a'",
+            dep: "'modules' with parentFolders 'test/fixtures/base-pattern', domain 'domain-b' and elementName 'module-c'",
+          }),
           type: "ImportDeclaration",
         },
       ],
@@ -198,7 +213,10 @@ ruleTester.run(RULE, rule, {
       options,
       errors: [
         {
-          message: ELEMENT_TYPES_DEFAULT_MESSAGE,
+          message: elementTypesNoRuleMessage({
+            file: "'components' with parentFolders 'test/fixtures/base-pattern', domain 'domain-a', type 'molecules' and elementName 'molecule-a'",
+            dep: "'components' with parentFolders 'test/fixtures/base-pattern', domain 'domain-b', type 'atoms' and elementName 'atom-c'",
+          }),
           type: "ImportDeclaration",
         },
       ],
@@ -212,7 +230,10 @@ ruleTester.run(RULE, rule, {
       options,
       errors: [
         {
-          message: ELEMENT_TYPES_DEFAULT_MESSAGE,
+          message: elementTypesNoRuleMessage({
+            file: "'components' with parentFolders 'test/fixtures/base-pattern', domain 'domain-a', type 'molecules' and elementName 'molecule-e'",
+            dep: "'components' with parentFolders 'test/fixtures/base-pattern', domain 'domain-b', type 'atoms' and elementName 'atom-c'",
+          }),
           type: "ImportDeclaration",
         },
       ],
@@ -224,7 +245,10 @@ ruleTester.run(RULE, rule, {
       options,
       errors: [
         {
-          message: ELEMENT_TYPES_DEFAULT_MESSAGE,
+          message: elementTypesNoRuleMessage({
+            file: "'components' with parentFolders 'test/fixtures/base-pattern', domain 'domain-b', type 'molecules' and elementName 'molecule-c'",
+            dep: "'modules' with parentFolders 'test/fixtures/base-pattern', domain 'domain-b' and elementName 'module-c'",
+          }),
           type: "ImportDeclaration",
         },
       ],
@@ -236,7 +260,10 @@ ruleTester.run(RULE, rule, {
       options,
       errors: [
         {
-          message: ELEMENT_TYPES_DEFAULT_MESSAGE,
+          message: elementTypesNoRuleMessage({
+            file: "'components' with parentFolders 'test/fixtures/base-pattern', domain 'domain-b', type 'molecules' and elementName 'molecule-c'",
+            dep: "'modules' with parentFolders 'test/fixtures/base-pattern', domain 'domain-a' and elementName 'module-a'",
+          }),
           type: "ImportDeclaration",
         },
       ],

--- a/test/rules/base-pattern/element-types.spec.js
+++ b/test/rules/base-pattern/element-types.spec.js
@@ -1,10 +1,8 @@
 const { ELEMENT_TYPES: RULE } = require("../../../src/constants/rules");
 const { SETTINGS, createRuleTester, pathResolvers } = require("../../support/helpers");
+const { ELEMENT_TYPES_DEFAULT_MESSAGE } = require("../../support/messages");
 
 const rule = require(`../../../src/rules/${RULE}`);
-
-const errorMessage = (fileType, dependencyType) =>
-  `Usage of '${dependencyType}' is not allowed in '${fileType}'`;
 
 const settings = SETTINGS.basePattern;
 
@@ -140,7 +138,7 @@ ruleTester.run(RULE, rule, {
       options,
       errors: [
         {
-          message: errorMessage("modules", "modules"),
+          message: ELEMENT_TYPES_DEFAULT_MESSAGE,
           type: "ImportDeclaration",
         },
       ],
@@ -152,7 +150,7 @@ ruleTester.run(RULE, rule, {
       options,
       errors: [
         {
-          message: errorMessage("modules", "modules"),
+          message: ELEMENT_TYPES_DEFAULT_MESSAGE,
           type: "ImportDeclaration",
         },
       ],
@@ -164,7 +162,7 @@ ruleTester.run(RULE, rule, {
       options,
       errors: [
         {
-          message: errorMessage("modules", "components"),
+          message: ELEMENT_TYPES_DEFAULT_MESSAGE,
           type: "ImportDeclaration",
         },
       ],
@@ -176,7 +174,7 @@ ruleTester.run(RULE, rule, {
       options,
       errors: [
         {
-          message: errorMessage("components", "modules"),
+          message: ELEMENT_TYPES_DEFAULT_MESSAGE,
           type: "ImportDeclaration",
         },
       ],
@@ -188,7 +186,7 @@ ruleTester.run(RULE, rule, {
       options,
       errors: [
         {
-          message: errorMessage("components", "modules"),
+          message: ELEMENT_TYPES_DEFAULT_MESSAGE,
           type: "ImportDeclaration",
         },
       ],
@@ -200,7 +198,7 @@ ruleTester.run(RULE, rule, {
       options,
       errors: [
         {
-          message: errorMessage("components", "components"),
+          message: ELEMENT_TYPES_DEFAULT_MESSAGE,
           type: "ImportDeclaration",
         },
       ],
@@ -214,7 +212,7 @@ ruleTester.run(RULE, rule, {
       options,
       errors: [
         {
-          message: errorMessage("components", "components"),
+          message: ELEMENT_TYPES_DEFAULT_MESSAGE,
           type: "ImportDeclaration",
         },
       ],
@@ -226,7 +224,7 @@ ruleTester.run(RULE, rule, {
       options,
       errors: [
         {
-          message: errorMessage("components", "modules"),
+          message: ELEMENT_TYPES_DEFAULT_MESSAGE,
           type: "ImportDeclaration",
         },
       ],
@@ -238,7 +236,7 @@ ruleTester.run(RULE, rule, {
       options,
       errors: [
         {
-          message: errorMessage("components", "modules"),
+          message: ELEMENT_TYPES_DEFAULT_MESSAGE,
           type: "ImportDeclaration",
         },
       ],

--- a/test/rules/docs-examples/element-types.spec.js
+++ b/test/rules/docs-examples/element-types.spec.js
@@ -1,6 +1,6 @@
 const { ELEMENT_TYPES: RULE } = require("../../../src/constants/rules");
 const { SETTINGS, createRuleTester, pathResolvers } = require("../../support/helpers");
-const { ELEMENT_TYPES_DEFAULT_MESSAGE } = require("../../support/messages");
+const { elementTypesNoRuleMessage } = require("../../support/messages");
 
 const rule = require(`../../../src/rules/${RULE}`);
 
@@ -101,7 +101,10 @@ ruleTester.run(RULE, rule, {
       options,
       errors: [
         {
-          message: ELEMENT_TYPES_DEFAULT_MESSAGE,
+          message: elementTypesNoRuleMessage({
+            file: "'helpers' with category 'permissions' and elementName 'roles'",
+            dep: "'components' with family 'atoms' and elementName 'atom-a'",
+          }),
           type: "ImportDeclaration",
         },
       ],
@@ -113,7 +116,10 @@ ruleTester.run(RULE, rule, {
       options,
       errors: [
         {
-          message: ELEMENT_TYPES_DEFAULT_MESSAGE,
+          message: elementTypesNoRuleMessage({
+            file: "'helpers' with category 'permissions' and elementName 'roles'",
+            dep: "'modules' with elementName 'module-a'",
+          }),
           type: "ImportDeclaration",
         },
       ],
@@ -125,7 +131,10 @@ ruleTester.run(RULE, rule, {
       options,
       errors: [
         {
-          message: ELEMENT_TYPES_DEFAULT_MESSAGE,
+          message: elementTypesNoRuleMessage({
+            file: "'components' with family 'atoms' and elementName 'atom-a'",
+            dep: "'components' with family 'molecules' and elementName 'molecule-a'",
+          }),
           type: "ImportDeclaration",
         },
       ],
@@ -137,7 +146,10 @@ ruleTester.run(RULE, rule, {
       options,
       errors: [
         {
-          message: ELEMENT_TYPES_DEFAULT_MESSAGE,
+          message: elementTypesNoRuleMessage({
+            file: "'components' with family 'atoms' and elementName 'atom-a'",
+            dep: "'helpers' with category 'permissions' and elementName 'roles'",
+          }),
           type: "ImportDeclaration",
         },
       ],
@@ -149,7 +161,10 @@ ruleTester.run(RULE, rule, {
       options,
       errors: [
         {
-          message: ELEMENT_TYPES_DEFAULT_MESSAGE,
+          message: elementTypesNoRuleMessage({
+            file: "'components' with family 'atoms' and elementName 'atom-a'",
+            dep: "'modules' with elementName 'module-a'",
+          }),
           type: "ImportDeclaration",
         },
       ],

--- a/test/rules/docs-examples/element-types.spec.js
+++ b/test/rules/docs-examples/element-types.spec.js
@@ -1,10 +1,8 @@
 const { ELEMENT_TYPES: RULE } = require("../../../src/constants/rules");
 const { SETTINGS, createRuleTester, pathResolvers } = require("../../support/helpers");
+const { ELEMENT_TYPES_DEFAULT_MESSAGE } = require("../../support/messages");
 
 const rule = require(`../../../src/rules/${RULE}`);
-
-const errorMessage = (fileType, dependencyType) =>
-  `Usage of '${dependencyType}' is not allowed in '${fileType}'`;
 
 const { absoluteFilePath } = pathResolvers("docs-examples");
 
@@ -103,7 +101,7 @@ ruleTester.run(RULE, rule, {
       options,
       errors: [
         {
-          message: errorMessage("helpers", "components"),
+          message: ELEMENT_TYPES_DEFAULT_MESSAGE,
           type: "ImportDeclaration",
         },
       ],
@@ -115,7 +113,7 @@ ruleTester.run(RULE, rule, {
       options,
       errors: [
         {
-          message: errorMessage("helpers", "modules"),
+          message: ELEMENT_TYPES_DEFAULT_MESSAGE,
           type: "ImportDeclaration",
         },
       ],
@@ -127,7 +125,7 @@ ruleTester.run(RULE, rule, {
       options,
       errors: [
         {
-          message: errorMessage("components", "components"),
+          message: ELEMENT_TYPES_DEFAULT_MESSAGE,
           type: "ImportDeclaration",
         },
       ],
@@ -139,7 +137,7 @@ ruleTester.run(RULE, rule, {
       options,
       errors: [
         {
-          message: errorMessage("components", "helpers"),
+          message: ELEMENT_TYPES_DEFAULT_MESSAGE,
           type: "ImportDeclaration",
         },
       ],
@@ -151,7 +149,7 @@ ruleTester.run(RULE, rule, {
       options,
       errors: [
         {
-          message: errorMessage("components", "modules"),
+          message: ELEMENT_TYPES_DEFAULT_MESSAGE,
           type: "ImportDeclaration",
         },
       ],

--- a/test/rules/nestjs-example/element-types.spec.js
+++ b/test/rules/nestjs-example/element-types.spec.js
@@ -1,12 +1,10 @@
 const { ELEMENT_TYPES: RULE } = require("../../../src/constants/rules");
 const { createRuleTester, pathResolvers } = require("../../support/helpers");
+const { elementTypesErrorMessage } = require("../../support/messages");
 
 const rule = require(`../../../src/rules/${RULE}`);
 
-const errorMessage = (fileType, dependencyType) =>
-  `Usage of '${dependencyType}' is not allowed in '${fileType}'`;
-
-const test = (settings, options, { absoluteFilePath }) => {
+const test = (settings, options, { absoluteFilePath }, errorMessages) => {
   const ruleTester = createRuleTester(settings);
 
   ruleTester.run(RULE, rule, {
@@ -110,7 +108,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("app", "interface"),
+            message: elementTypesErrorMessage(errorMessages, 0),
             type: "ImportDeclaration",
           },
         ],
@@ -122,7 +120,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("app", "controller"),
+            message: elementTypesErrorMessage(errorMessages, 1),
             type: "ImportDeclaration",
           },
         ],
@@ -134,7 +132,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("app", "service"),
+            message: elementTypesErrorMessage(errorMessages, 2),
             type: "ImportDeclaration",
           },
         ],
@@ -146,7 +144,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("module", "controller"),
+            message: elementTypesErrorMessage(errorMessages, 3),
             type: "ImportDeclaration",
           },
         ],
@@ -158,7 +156,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("module", "service"),
+            message: elementTypesErrorMessage(errorMessages, 4),
             type: "ImportDeclaration",
           },
         ],
@@ -170,7 +168,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("module", "interceptor"),
+            message: elementTypesErrorMessage(errorMessages, 5),
             type: "ImportDeclaration",
           },
         ],
@@ -182,7 +180,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("module", "interceptor"),
+            message: elementTypesErrorMessage(errorMessages, 6),
             type: "ImportDeclaration",
           },
         ],
@@ -194,7 +192,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("controller", "service"),
+            message: elementTypesErrorMessage(errorMessages, 7),
             type: "ImportDeclaration",
           },
         ],
@@ -206,7 +204,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("controller", "dto"),
+            message: elementTypesErrorMessage(errorMessages, 8),
             type: "ImportDeclaration",
           },
         ],
@@ -218,7 +216,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("controller", "interface"),
+            message: elementTypesErrorMessage(errorMessages, 9),
             type: "ImportDeclaration",
           },
         ],
@@ -230,7 +228,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("controller", "model"),
+            message: elementTypesErrorMessage(errorMessages, 10),
             type: "ImportDeclaration",
           },
         ],
@@ -242,7 +240,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("controller", "model"),
+            message: elementTypesErrorMessage(errorMessages, 11),
             type: "ImportDeclaration",
           },
         ],
@@ -254,7 +252,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("controller", "model"),
+            message: elementTypesErrorMessage(errorMessages, 12),
             type: "ImportDeclaration",
           },
         ],
@@ -362,7 +360,8 @@ test(
     ],
   },
   ruleOptions,
-  pathResolvers("nestjs-example")
+  pathResolvers("nestjs-example"),
+  {}
 );
 
 test(
@@ -435,7 +434,8 @@ test(
     ],
   },
   ruleOptions,
-  pathResolvers("nestjs-example")
+  pathResolvers("nestjs-example"),
+  {}
 );
 
 test(
@@ -508,5 +508,6 @@ test(
     ],
   },
   ruleOptions,
-  pathResolvers("nestjs-example")
+  pathResolvers("nestjs-example"),
+  {}
 );

--- a/test/rules/nestjs-example/element-types.spec.js
+++ b/test/rules/nestjs-example/element-types.spec.js
@@ -1,10 +1,10 @@
 const { ELEMENT_TYPES: RULE } = require("../../../src/constants/rules");
 const { createRuleTester, pathResolvers } = require("../../support/helpers");
-const { elementTypesErrorMessage } = require("../../support/messages");
+const { elementTypesErrorMessage, elementTypesNoRuleMessage } = require("../../support/messages");
 
 const rule = require(`../../../src/rules/${RULE}`);
 
-const test = (settings, options, { absoluteFilePath }, errorMessages) => {
+const test = (settings, options, { absoluteFilePath }, errorMessages, base) => {
   const ruleTester = createRuleTester(settings);
 
   ruleTester.run(RULE, rule, {
@@ -108,7 +108,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 0),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              0,
+              elementTypesNoRuleMessage({
+                file: "'app'",
+                dep: "'interface' with base '', feature 'cats' and fileName 'cats'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -120,7 +127,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 1),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              1,
+              elementTypesNoRuleMessage({
+                file: "'app'",
+                dep: "'controller' with base '', feature 'cats' and fileName 'cats'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -132,7 +146,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 2),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              2,
+              elementTypesNoRuleMessage({
+                file: "'app'",
+                dep: "'service' with base '', feature 'cats' and fileName 'cats'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -144,7 +165,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 3),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              3,
+              elementTypesNoRuleMessage({
+                file: "'module' with base '', feature 'core' and fileName 'core'",
+                dep: "'controller' with base '', feature 'cats' and fileName 'cats'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -156,7 +184,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 4),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              4,
+              elementTypesNoRuleMessage({
+                file: "'module' with base '', feature 'core' and fileName 'core'",
+                dep: "'service' with base '', feature 'cats' and fileName 'cats'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -168,7 +203,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 5),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              5,
+              elementTypesNoRuleMessage({
+                file: "'module' with base '', feature 'cats' and fileName 'cats'",
+                dep: "'interceptor' with base '', feature 'core' and fileName 'logging'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -180,7 +222,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 6),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              6,
+              elementTypesNoRuleMessage({
+                file: "'module' with base '', feature 'cats' and fileName 'cats'",
+                dep: "'interceptor' with base '', feature 'core' and fileName 'transform'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -192,7 +241,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 7),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              7,
+              elementTypesNoRuleMessage({
+                file: "'controller' with base '', feature 'core' and fileName 'core'",
+                dep: "'service' with base '', feature 'cats' and fileName 'cats'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -204,7 +260,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 8),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              8,
+              elementTypesNoRuleMessage({
+                file: "'controller' with base '', feature 'core' and fileName 'core'",
+                dep: "'dto' with base '', feature 'cats' and fileName 'create-cat'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -216,7 +279,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 9),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              9,
+              elementTypesNoRuleMessage({
+                file: "'controller' with base '', feature 'core' and fileName 'core'",
+                dep: "'interface' with base '', feature 'cats' and fileName 'cats'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -228,7 +298,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 10),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              10,
+              elementTypesNoRuleMessage({
+                file: "'controller' with base '', feature 'core' and fileName 'core'",
+                dep: `'model' with base '${base}', feature 'cats' and fileName 'persian-cat'`,
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -240,7 +317,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 11),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              11,
+              elementTypesNoRuleMessage({
+                file: "'controller' with base '', feature 'core' and fileName 'core'",
+                dep: `'model' with base '${base}', feature 'cats' and fileName 'siamese-cat'`,
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -252,7 +336,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 12),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              12,
+              elementTypesNoRuleMessage({
+                file: "'controller' with base '', feature 'cats' and fileName 'cats'",
+                dep: `'model' with base '${base}', feature 'core' and fileName 'core'`,
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -361,7 +452,8 @@ test(
   },
   ruleOptions,
   pathResolvers("nestjs-example"),
-  {}
+  {},
+  "test/fixtures/nestjs-example"
 );
 
 test(
@@ -435,7 +527,13 @@ test(
   },
   ruleOptions,
   pathResolvers("nestjs-example"),
-  {}
+  {
+    12: elementTypesNoRuleMessage({
+      file: "'controller' with base '', feature 'cats' and fileName 'cats'",
+      dep: `'model' with base 'nestjs-example', feature 'core' and fileName 'core'`,
+    }),
+  },
+  ""
 );
 
 test(
@@ -509,5 +607,11 @@ test(
   },
   ruleOptions,
   pathResolvers("nestjs-example"),
-  {}
+  {
+    12: elementTypesNoRuleMessage({
+      file: "'controller' with base '', feature 'cats' and fileName 'cats'",
+      dep: `'model' with base '', feature 'core' and fileName 'core'`,
+    }),
+  },
+  "test/fixtures/nestjs-example"
 );

--- a/test/rules/one-level/element-types.spec.js
+++ b/test/rules/one-level/element-types.spec.js
@@ -632,6 +632,36 @@ testCapture(
   }
 );
 
+// Custom error message default
+
+testCapture(
+  SETTINGS.oneLevel,
+  [
+    {
+      default: "disallow",
+      message:
+        "Importing ${dependency.type} with name ${dependency.elementName} is not allowed in ${file.type} with name ${file.elementName}",
+      rules: [
+        {
+          from: "c*",
+          allow: [["helpers", { elementName: "*-a" }], "c*"],
+          disallow: [["c*", { elementName: "*-a" }]],
+        },
+        {
+          from: "modules",
+          allow: [["h*", { elementName: "*-a" }], "c*", "m*"],
+        },
+      ],
+    },
+  ],
+  {
+    0: "Importing helpers with name helper-b is not allowed in components with name component-a",
+    1: "Importing helpers with name helper-b is not allowed in components with name component-a",
+    2: "Importing components with name component-a is not allowed in components with name component-b",
+    3: "Importing helpers with name helper-b is not allowed in modules with name module-a",
+  }
+);
+
 testCapture(
   SETTINGS.oneLevel,
   [

--- a/test/rules/one-level/element-types.spec.js
+++ b/test/rules/one-level/element-types.spec.js
@@ -1,14 +1,12 @@
 const { ELEMENT_TYPES: RULE } = require("../../../src/constants/rules");
 const { SETTINGS, createRuleTester, pathResolvers } = require("../../support/helpers");
+const { elementTypesErrorMessage } = require("../../support/messages");
 
 const rule = require(`../../../src/rules/${RULE}`);
 
 const { absoluteFilePath, codeFilePath } = pathResolvers("one-level");
 
-const errorMessage = (fileType, dependencyType) =>
-  `Usage of '${dependencyType}' is not allowed in '${fileType}'`;
-
-const test = (settings, options) => {
+const test = (settings, options, errorMessages) => {
   const ruleTester = createRuleTester(settings);
 
   ruleTester.run(RULE, rule, {
@@ -180,7 +178,7 @@ const test = (settings, options) => {
         ],
         errors: [
           {
-            message: errorMessage("helpers", "helpers"),
+            message: elementTypesErrorMessage(errorMessages, 0),
             type: "ImportDeclaration",
           },
         ],
@@ -192,7 +190,7 @@ const test = (settings, options) => {
         options,
         errors: [
           {
-            message: errorMessage("helpers", "helpers"),
+            message: elementTypesErrorMessage(errorMessages, 1),
             type: "ImportDeclaration",
           },
         ],
@@ -204,7 +202,7 @@ const test = (settings, options) => {
         options,
         errors: [
           {
-            message: errorMessage("helpers", "components"),
+            message: elementTypesErrorMessage(errorMessages, 2),
             type: "ImportDeclaration",
           },
         ],
@@ -216,7 +214,7 @@ const test = (settings, options) => {
         options,
         errors: [
           {
-            message: errorMessage("helpers", "modules"),
+            message: elementTypesErrorMessage(errorMessages, 3),
             type: "ImportDeclaration",
           },
         ],
@@ -228,7 +226,7 @@ const test = (settings, options) => {
         options,
         errors: [
           {
-            message: errorMessage("components", "modules"),
+            message: elementTypesErrorMessage(errorMessages, 4),
             type: "ImportDeclaration",
           },
         ],
@@ -237,7 +235,7 @@ const test = (settings, options) => {
   });
 };
 
-const testCapture = (settings, options) => {
+const testCapture = (settings, options, errorMessages) => {
   const ruleTester = createRuleTester(settings);
 
   ruleTester.run(RULE, rule, {
@@ -281,7 +279,7 @@ const testCapture = (settings, options) => {
         options,
         errors: [
           {
-            message: errorMessage("components", "helpers"),
+            message: elementTypesErrorMessage(errorMessages, 0),
             type: "ImportDeclaration",
           },
         ],
@@ -293,7 +291,7 @@ const testCapture = (settings, options) => {
         options,
         errors: [
           {
-            message: errorMessage("components", "helpers"),
+            message: elementTypesErrorMessage(errorMessages, 1),
             type: "ImportDeclaration",
           },
         ],
@@ -305,7 +303,7 @@ const testCapture = (settings, options) => {
         options,
         errors: [
           {
-            message: errorMessage("components", "components"),
+            message: elementTypesErrorMessage(errorMessages, 2),
             type: "ImportDeclaration",
           },
         ],
@@ -317,7 +315,7 @@ const testCapture = (settings, options) => {
         options,
         errors: [
           {
-            message: errorMessage("modules", "helpers"),
+            message: elementTypesErrorMessage(errorMessages, 3),
             type: "ImportDeclaration",
           },
         ],
@@ -328,21 +326,25 @@ const testCapture = (settings, options) => {
 
 // deprecated settings
 
-test(SETTINGS.deprecated, [
-  {
-    default: "disallow",
-    rules: [
-      {
-        from: "components",
-        allow: ["helpers", "components"],
-      },
-      {
-        from: "modules",
-        allow: ["helpers", "components", "modules"],
-      },
-    ],
-  },
-]);
+test(
+  SETTINGS.deprecated,
+  [
+    {
+      default: "disallow",
+      rules: [
+        {
+          from: "components",
+          allow: ["helpers", "components"],
+        },
+        {
+          from: "modules",
+          allow: ["helpers", "components", "modules"],
+        },
+      ],
+    },
+  ],
+  {}
+);
 
 // settings with no capture option
 test(
@@ -377,117 +379,202 @@ test(
         },
       ],
     },
-  ]
+  ],
+  {
+    1: "Importing elements of type 'modules', or elements of type 'components', or elements of type 'helpers' is not allowed in elements of type 'helpers'. Disallowed in rule 1",
+    2: "Importing elements of type 'modules', or elements of type 'components', or elements of type 'helpers' is not allowed in elements of type 'helpers'. Disallowed in rule 1",
+    3: "Importing elements of type 'modules', or elements of type 'components', or elements of type 'helpers' is not allowed in elements of type 'helpers'. Disallowed in rule 1",
+    4: "Importing elements of type 'modules' is not allowed in elements of type 'components'. Disallowed in rule 2",
+  }
 );
 
 // disallow-based options
 
-test(SETTINGS.oneLevel, [
-  {
-    default: "disallow",
-    rules: [
-      {
-        from: "components",
-        allow: ["helpers", "components"],
-      },
-      {
-        from: "modules",
-        allow: ["helpers", "components", "modules"],
-      },
-    ],
-  },
-]);
+test(
+  SETTINGS.oneLevel,
+  [
+    {
+      default: "disallow",
+      rules: [
+        {
+          from: "components",
+          allow: ["helpers", "components"],
+        },
+        {
+          from: "modules",
+          allow: ["helpers", "components", "modules"],
+        },
+      ],
+    },
+  ],
+  {}
+);
 
 // micromatch-based options
 
-test(SETTINGS.oneLevel, [
-  {
-    default: "disallow",
-    rules: [
-      {
-        from: "c*",
-        allow: ["h*", "c*"],
-      },
-      {
-        from: "m*",
-        allow: ["h*", "c*", "m*"],
-      },
-    ],
-  },
-]);
+test(
+  SETTINGS.oneLevel,
+  [
+    {
+      default: "disallow",
+      rules: [
+        {
+          from: "c*",
+          allow: ["h*", "c*"],
+        },
+        {
+          from: "m*",
+          allow: ["h*", "c*", "m*"],
+        },
+      ],
+    },
+  ],
+  {}
+);
 
 // allow-based options
-test(SETTINGS.oneLevel, [
+test(
+  SETTINGS.oneLevel,
+  [
+    {
+      default: "allow",
+      rules: [
+        {
+          from: "helpers",
+          disallow: ["modules", "components", "helpers"],
+        },
+        {
+          from: "components",
+          disallow: ["modules"],
+        },
+      ],
+    },
+  ],
   {
-    default: "allow",
-    rules: [
-      {
-        from: "helpers",
-        disallow: ["modules", "components", "helpers"],
-      },
-      {
-        from: "components",
-        disallow: ["modules"],
-      },
-    ],
-  },
-]);
+    1: "Importing elements of type 'modules', or elements of type 'components', or elements of type 'helpers' is not allowed in elements of type 'helpers'. Disallowed in rule 1",
+    2: "Importing elements of type 'modules', or elements of type 'components', or elements of type 'helpers' is not allowed in elements of type 'helpers'. Disallowed in rule 1",
+    3: "Importing elements of type 'modules', or elements of type 'components', or elements of type 'helpers' is not allowed in elements of type 'helpers'. Disallowed in rule 1",
+    4: "Importing elements of type 'modules' is not allowed in elements of type 'components'. Disallowed in rule 2",
+  }
+);
 
 // capture options
 
-testCapture(SETTINGS.oneLevel, [
+testCapture(
+  SETTINGS.oneLevel,
+  [
+    {
+      default: "disallow",
+      rules: [
+        {
+          from: "components",
+          allow: [["helpers", { elementName: "helper-a" }], "components"],
+          disallow: [["components", { elementName: "component-a" }]],
+        },
+        {
+          from: "modules",
+          allow: [["helpers", { elementName: "helper-a" }], "components", "modules"],
+        },
+      ],
+    },
+  ],
   {
-    default: "disallow",
-    rules: [
-      {
-        from: "components",
-        allow: [["helpers", { elementName: "helper-a" }], "components"],
-        disallow: [["components", { elementName: "component-a" }]],
-      },
-      {
-        from: "modules",
-        allow: [["helpers", { elementName: "helper-a" }], "components", "modules"],
-      },
-    ],
-  },
-]);
+    2: "Importing elements of type 'components' with elementName 'component-a' is not allowed in elements of type 'components'. Disallowed in rule 1",
+  }
+);
 
 // capture options with micromatch negative expression
 
-testCapture(SETTINGS.oneLevel, [
-  {
-    default: "disallow",
-    rules: [
-      {
-        from: "components",
-        allow: [
-          ["helpers", { elementName: "helper-a" }],
-          ["components", { elementName: "!component-a" }],
-        ],
-      },
-      {
-        from: "modules",
-        allow: [["helpers", { elementName: "helper-a" }], "components", "modules"],
-      },
-    ],
-  },
-]);
+testCapture(
+  SETTINGS.oneLevel,
+  [
+    {
+      default: "disallow",
+      rules: [
+        {
+          from: "components",
+          allow: [
+            ["helpers", { elementName: "helper-a" }],
+            ["components", { elementName: "!component-a" }],
+          ],
+        },
+        {
+          from: "modules",
+          allow: [["helpers", { elementName: "helper-a" }], "components", "modules"],
+        },
+      ],
+    },
+  ],
+  {}
+);
 
 // capture options with micromatch
 
-testCapture(SETTINGS.oneLevel, [
+testCapture(
+  SETTINGS.oneLevel,
+  [
+    {
+      default: "disallow",
+      rules: [
+        {
+          from: "c*",
+          allow: [["helpers", { elementName: "*-a" }], "c*"],
+          disallow: [["c*", { elementName: "*-a" }]],
+        },
+        {
+          from: "modules",
+          allow: [["h*", { elementName: "*-a" }], "c*", "m*"],
+        },
+      ],
+    },
+  ],
   {
-    default: "disallow",
-    rules: [
-      {
-        from: "c*",
-        allow: [["helpers", { elementName: "*-a" }], "c*"],
-        disallow: [["c*", { elementName: "*-a" }]],
-      },
-      {
-        from: "modules",
-        allow: [["h*", { elementName: "*-a" }], "c*", "m*"],
-      },
-    ],
-  },
-]);
+    2: "Importing elements of type 'c*' with elementName '*-a' is not allowed in elements of type 'c*'. Disallowed in rule 1",
+  }
+);
+
+testCapture(
+  SETTINGS.oneLevel,
+  [
+    {
+      default: "disallow",
+      rules: [
+        {
+          from: "c*",
+          allow: [["helpers", { elementName: "*-a" }], "c*"],
+          disallow: [["c*", { elementName: ["*-a", "component-a", "*t-a"] }]],
+        },
+        {
+          from: "modules",
+          allow: [["h*", { elementName: "*-a" }], "c*", "m*"],
+        },
+      ],
+    },
+  ],
+  {
+    2: "Importing elements of type 'c*' with elementName '*-a', 'component-a' or '*t-a' is not allowed in elements of type 'c*'. Disallowed in rule 1",
+  }
+);
+
+testCapture(
+  SETTINGS.oneLevel,
+  [
+    {
+      default: "disallow",
+      rules: [
+        {
+          from: ["c*"],
+          allow: [["helpers", { elementName: "*-a" }], "c*"],
+          disallow: [["c*", { elementName: ["*-a"] }]],
+        },
+        {
+          from: "modules",
+          allow: [["h*", { elementName: "*-a" }], "c*", "m*"],
+        },
+      ],
+    },
+  ],
+  {
+    2: "Importing elements of type 'c*' with elementName '*-a' is not allowed in elements of type 'c*'. Disallowed in rule 1",
+  }
+);

--- a/test/rules/one-level/element-types.spec.js
+++ b/test/rules/one-level/element-types.spec.js
@@ -1,6 +1,6 @@
 const { ELEMENT_TYPES: RULE } = require("../../../src/constants/rules");
 const { SETTINGS, createRuleTester, pathResolvers } = require("../../support/helpers");
-const { elementTypesErrorMessage } = require("../../support/messages");
+const { elementTypesErrorMessage, elementTypesNoRuleMessage } = require("../../support/messages");
 
 const rule = require(`../../../src/rules/${RULE}`);
 
@@ -178,7 +178,14 @@ const test = (settings, options, errorMessages) => {
         ],
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 0),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              0,
+              elementTypesNoRuleMessage({
+                file: "'helpers' with elementName 'helper-a'",
+                dep: "'helpers' with elementName 'helper-b'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -190,7 +197,14 @@ const test = (settings, options, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 1),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              1,
+              elementTypesNoRuleMessage({
+                file: "'helpers' with elementName 'helper-a'",
+                dep: "'helpers' with elementName 'helper-b'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -202,7 +216,14 @@ const test = (settings, options, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 2),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              2,
+              elementTypesNoRuleMessage({
+                file: "'helpers' with elementName 'helper-a'",
+                dep: "'components' with elementName 'component-a'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -214,7 +235,14 @@ const test = (settings, options, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 3),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              3,
+              elementTypesNoRuleMessage({
+                file: "'helpers' with elementName 'helper-a'",
+                dep: "'modules' with elementName 'module-a'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -226,7 +254,14 @@ const test = (settings, options, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 4),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              4,
+              elementTypesNoRuleMessage({
+                file: "'components' with elementName 'component-a'",
+                dep: "'modules' with elementName 'module-a'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -279,7 +314,14 @@ const testCapture = (settings, options, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 0),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              0,
+              elementTypesNoRuleMessage({
+                file: "'components' with elementName 'component-a'",
+                dep: "'helpers' with elementName 'helper-b'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -291,7 +333,14 @@ const testCapture = (settings, options, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 1),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              1,
+              elementTypesNoRuleMessage({
+                file: "'components' with elementName 'component-a'",
+                dep: "'helpers' with elementName 'helper-b'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -303,7 +352,14 @@ const testCapture = (settings, options, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 2),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              2,
+              elementTypesNoRuleMessage({
+                file: "'components' with elementName 'component-b'",
+                dep: "'components' with elementName 'component-a'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -315,7 +371,14 @@ const testCapture = (settings, options, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 3),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              3,
+              elementTypesNoRuleMessage({
+                file: "'modules' with elementName 'module-a'",
+                dep: "'helpers' with elementName 'helper-b'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -381,6 +444,10 @@ test(
     },
   ],
   {
+    0: elementTypesNoRuleMessage({
+      file: "'helpers'",
+      dep: "'helpers'",
+    }),
     1: "Importing elements of type 'modules', or elements of type 'components', or elements of type 'helpers' is not allowed in elements of type 'helpers'. Disallowed in rule 1",
     2: "Importing elements of type 'modules', or elements of type 'components', or elements of type 'helpers' is not allowed in elements of type 'helpers'. Disallowed in rule 1",
     3: "Importing elements of type 'modules', or elements of type 'components', or elements of type 'helpers' is not allowed in elements of type 'helpers'. Disallowed in rule 1",

--- a/test/rules/one-level/element-types.spec.js
+++ b/test/rules/one-level/element-types.spec.js
@@ -533,6 +533,38 @@ testCapture(
   }
 );
 
+// Custom error message
+
+testCapture(
+  SETTINGS.oneLevel,
+  [
+    {
+      default: "disallow",
+      message:
+        "Importing ${dependency.type} with name ${dependency.elementName} is not allowed in ${file.type} with name ${file.elementName}",
+      rules: [
+        {
+          from: "c*",
+          allow: [["helpers", { elementName: "*-a" }], "c*"],
+          disallow: [["c*", { elementName: "*-a" }]],
+          message:
+            "Do not import ${dependency.type} named ${dependency.elementName} from ${file.type} named ${file.elementName}",
+        },
+        {
+          from: "modules",
+          allow: [["h*", { elementName: "*-a" }], "c*", "m*"],
+        },
+      ],
+    },
+  ],
+  {
+    0: "Importing helpers with name helper-b is not allowed in components with name component-a",
+    1: "Importing helpers with name helper-b is not allowed in components with name component-a",
+    2: "Do not import components named component-a from components named component-b",
+    3: "Importing helpers with name helper-b is not allowed in modules with name module-a",
+  }
+);
+
 testCapture(
   SETTINGS.oneLevel,
   [

--- a/test/rules/one-level/invalid-settings.spec.js
+++ b/test/rules/one-level/invalid-settings.spec.js
@@ -1,6 +1,6 @@
 const { ELEMENT_TYPES: RULE } = require("../../../src/constants/rules");
 const { SETTINGS, createRuleTester, pathResolvers } = require("../../support/helpers");
-const { elementTypesErrorMessage } = require("../../support/messages");
+const { elementTypesErrorMessage, elementTypesNoRuleMessage } = require("../../support/messages");
 
 const rule = require(`../../../src/rules/${RULE}`);
 
@@ -60,7 +60,14 @@ const test = (settings, options, errorMessages) => {
         ],
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 0),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              0,
+              elementTypesNoRuleMessage({
+                file: "'helpers' with elementName 'helper-a'",
+                dep: "'helpers' with elementName 'helper-b'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],

--- a/test/rules/one-level/invalid-settings.spec.js
+++ b/test/rules/one-level/invalid-settings.spec.js
@@ -1,14 +1,12 @@
 const { ELEMENT_TYPES: RULE } = require("../../../src/constants/rules");
 const { SETTINGS, createRuleTester, pathResolvers } = require("../../support/helpers");
+const { elementTypesErrorMessage } = require("../../support/messages");
 
 const rule = require(`../../../src/rules/${RULE}`);
 
 const { absoluteFilePath } = pathResolvers("one-level");
 
-const errorMessage = (fileType, dependencyType) =>
-  `Usage of '${dependencyType}' is not allowed in '${fileType}'`;
-
-const test = (settings, options) => {
+const test = (settings, options, errorMessages) => {
   const ruleTester = createRuleTester(settings);
 
   ruleTester.run(RULE, rule, {
@@ -62,7 +60,7 @@ const test = (settings, options) => {
         ],
         errors: [
           {
-            message: errorMessage("helpers", "helpers"),
+            message: elementTypesErrorMessage(errorMessages, 0),
             type: "ImportDeclaration",
           },
         ],
@@ -82,7 +80,8 @@ test(
     {
       default: "disallow",
     },
-  ]
+  ],
+  {}
 );
 
 // no type
@@ -97,7 +96,8 @@ test(
       },
     ],
   },
-  []
+  [],
+  {}
 );
 
 // no valid mode
@@ -111,7 +111,8 @@ test(
       },
     ],
   },
-  []
+  [],
+  {}
 );
 
 // no valid capture
@@ -126,5 +127,6 @@ test(
       },
     ],
   },
-  []
+  [],
+  {}
 );

--- a/test/rules/two-levels/element-types.spec.js
+++ b/test/rules/two-levels/element-types.spec.js
@@ -897,7 +897,7 @@ testPrivate(
         },
         {
           from: [["modules", { domain: "domain-a" }]],
-          disallow: [["modules", { domain: "domain-b" }]],
+          disallow: [["modules", { domain: ["!${domain}", "domain-b"] }]],
         },
       ],
     },
@@ -914,7 +914,7 @@ testPrivate(
     7: "Importing elements of type 'components' with category 'molecules' is not allowed in elements of type 'modules' with domain 'pages'. Disallowed in rule 7",
     8: "Importing elements of type 'modules' with domain 'domain-a' is not allowed in elements of type 'modules' with domain 'pages'. Disallowed in rule 6",
     9: "Importing elements of type 'components' with category 'molecules' is not allowed in elements of type 'modules' with domain 'domain-a'. Disallowed in rule 8",
-    10: "Importing elements of type 'modules' with domain 'pages' is not allowed in elements of type 'modules' with domain 'domain-a'. Disallowed in rule 9",
-    11: "Importing elements of type 'modules' with domain 'domain-b' is not allowed in elements of type 'modules' with domain 'domain-a'. Disallowed in rule 10",
+    10: "Importing elements of type 'modules' with domain '!domain-a' or 'domain-b' is not allowed in elements of type 'modules' with domain 'domain-a'. Disallowed in rule 10",
+    11: "Importing elements of type 'modules' with domain '!domain-a' or 'domain-b' is not allowed in elements of type 'modules' with domain 'domain-a'. Disallowed in rule 10",
   }
 );

--- a/test/rules/two-levels/element-types.spec.js
+++ b/test/rules/two-levels/element-types.spec.js
@@ -1,12 +1,10 @@
 const { ELEMENT_TYPES: RULE } = require("../../../src/constants/rules");
 const { SETTINGS, createRuleTester, pathResolvers } = require("../../support/helpers");
+const { elementTypesErrorMessage } = require("../../support/messages");
 
 const rule = require(`../../../src/rules/${RULE}`);
 
-const errorMessage = (fileType, dependencyType) =>
-  `Usage of '${dependencyType}' is not allowed in '${fileType}'`;
-
-const test = (settings, options, { absoluteFilePath }) => {
+const test = (settings, options, { absoluteFilePath }, errorMessages) => {
   const ruleTester = createRuleTester(settings);
 
   ruleTester.run(RULE, rule, {
@@ -172,7 +170,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("helpers", "components"),
+            message: elementTypesErrorMessage(errorMessages, 0),
             type: "ImportDeclaration",
           },
         ],
@@ -184,7 +182,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("helpers", "modules"),
+            message: elementTypesErrorMessage(errorMessages, 1),
             type: "ImportDeclaration",
           },
         ],
@@ -196,7 +194,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("components", "components"),
+            message: elementTypesErrorMessage(errorMessages, 2),
             type: "ImportDeclaration",
           },
         ],
@@ -208,7 +206,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("components", "components"),
+            message: elementTypesErrorMessage(errorMessages, 3),
             type: "ImportDeclaration",
           },
         ],
@@ -220,7 +218,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("components", "components"),
+            message: elementTypesErrorMessage(errorMessages, 4),
             type: "ImportDeclaration",
           },
         ],
@@ -232,7 +230,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("components", "components"),
+            message: elementTypesErrorMessage(errorMessages, 5),
             type: "ImportDeclaration",
           },
         ],
@@ -244,7 +242,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("components", "modules"),
+            message: elementTypesErrorMessage(errorMessages, 6),
             type: "ImportDeclaration",
           },
         ],
@@ -256,7 +254,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("components", "components"),
+            message: elementTypesErrorMessage(errorMessages, 7),
             type: "ImportDeclaration",
           },
         ],
@@ -268,7 +266,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("components", "modules"),
+            message: elementTypesErrorMessage(errorMessages, 8),
             type: "ImportDeclaration",
           },
         ],
@@ -280,7 +278,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("modules", "components"),
+            message: elementTypesErrorMessage(errorMessages, 9),
             type: "ImportDeclaration",
           },
         ],
@@ -292,7 +290,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("modules", "components"),
+            message: elementTypesErrorMessage(errorMessages, 10),
             type: "ImportDeclaration",
           },
         ],
@@ -304,7 +302,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("modules", "modules"),
+            message: elementTypesErrorMessage(errorMessages, 11),
             type: "ImportDeclaration",
           },
         ],
@@ -316,7 +314,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("modules", "modules"),
+            message: elementTypesErrorMessage(errorMessages, 12),
             type: "ImportDeclaration",
           },
         ],
@@ -328,7 +326,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("modules", "modules"),
+            message: elementTypesErrorMessage(errorMessages, 13),
             type: "ImportDeclaration",
           },
         ],
@@ -341,7 +339,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("modules", "components"),
+            message: elementTypesErrorMessage(errorMessages, 14),
             type: "ImportDeclaration",
           },
         ],
@@ -353,7 +351,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("modules", "components"),
+            message: elementTypesErrorMessage(errorMessages, 15),
             type: "ImportDeclaration",
           },
         ],
@@ -365,7 +363,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("modules", "components"),
+            message: elementTypesErrorMessage(errorMessages, 16),
             type: "ImportDeclaration",
           },
         ],
@@ -377,7 +375,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("modules", "modules"),
+            message: elementTypesErrorMessage(errorMessages, 17),
             type: "ImportDeclaration",
           },
         ],
@@ -389,7 +387,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("modules", "modules"),
+            message: elementTypesErrorMessage(errorMessages, 18),
             type: "ImportDeclaration",
           },
         ],
@@ -401,7 +399,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("modules", "modules"),
+            message: elementTypesErrorMessage(errorMessages, 19),
             type: "ImportDeclaration",
           },
         ],
@@ -413,7 +411,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("modules", "components"),
+            message: elementTypesErrorMessage(errorMessages, 20),
             type: "ImportDeclaration",
           },
         ],
@@ -425,7 +423,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("modules", "components"),
+            message: elementTypesErrorMessage(errorMessages, 21),
             type: "ImportDeclaration",
           },
         ],
@@ -437,7 +435,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("modules", "modules"),
+            message: elementTypesErrorMessage(errorMessages, 22),
             type: "ImportDeclaration",
           },
         ],
@@ -449,7 +447,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("modules", "components"),
+            message: elementTypesErrorMessage(errorMessages, 23),
             type: "ImportDeclaration",
           },
         ],
@@ -461,7 +459,7 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("modules", "components"),
+            message: elementTypesErrorMessage(errorMessages, 24),
             type: "ImportDeclaration",
           },
         ],
@@ -470,7 +468,7 @@ const test = (settings, options, { absoluteFilePath }) => {
   });
 };
 
-const testPrivate = (settings, options, { absoluteFilePath }) => {
+const testPrivate = (settings, options, { absoluteFilePath }, errorMessages) => {
   const ruleTester = createRuleTester(settings);
 
   ruleTester.run(RULE, rule, {
@@ -586,7 +584,7 @@ const testPrivate = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("helpers", "components"),
+            message: elementTypesErrorMessage(errorMessages, 0),
             type: "ImportDeclaration",
           },
         ],
@@ -598,7 +596,7 @@ const testPrivate = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("helpers", "modules"),
+            message: elementTypesErrorMessage(errorMessages, 1),
             type: "ImportDeclaration",
           },
         ],
@@ -610,7 +608,7 @@ const testPrivate = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("components", "components"),
+            message: elementTypesErrorMessage(errorMessages, 2),
             type: "ImportDeclaration",
           },
         ],
@@ -622,7 +620,7 @@ const testPrivate = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("components", "components"),
+            message: elementTypesErrorMessage(errorMessages, 3),
             type: "ImportDeclaration",
           },
         ],
@@ -636,7 +634,7 @@ const testPrivate = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("components", "components"),
+            message: elementTypesErrorMessage(errorMessages, 4),
             type: "ImportDeclaration",
           },
         ],
@@ -650,7 +648,7 @@ const testPrivate = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("components", "modules"),
+            message: elementTypesErrorMessage(errorMessages, 5),
             type: "ImportDeclaration",
           },
         ],
@@ -662,7 +660,7 @@ const testPrivate = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("components", "modules"),
+            message: elementTypesErrorMessage(errorMessages, 6),
             type: "ImportDeclaration",
           },
         ],
@@ -674,7 +672,7 @@ const testPrivate = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("modules", "components"),
+            message: elementTypesErrorMessage(errorMessages, 7),
             type: "ImportDeclaration",
           },
         ],
@@ -686,7 +684,7 @@ const testPrivate = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("modules", "modules"),
+            message: elementTypesErrorMessage(errorMessages, 8),
             type: "ImportDeclaration",
           },
         ],
@@ -698,7 +696,7 @@ const testPrivate = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("modules", "components"),
+            message: elementTypesErrorMessage(errorMessages, 9),
             type: "ImportDeclaration",
           },
         ],
@@ -710,7 +708,7 @@ const testPrivate = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("modules", "modules"),
+            message: elementTypesErrorMessage(errorMessages, 10),
             type: "ImportDeclaration",
           },
         ],
@@ -722,7 +720,7 @@ const testPrivate = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("modules", "modules"),
+            message: elementTypesErrorMessage(errorMessages, 11),
             type: "ImportDeclaration",
           },
         ],
@@ -784,7 +782,8 @@ test(
       ],
     },
   ],
-  pathResolvers("two-levels")
+  pathResolvers("two-levels"),
+  {}
 );
 
 testPrivate(
@@ -850,5 +849,72 @@ testPrivate(
       ],
     },
   ],
-  pathResolvers("two-levels-with-private")
+  pathResolvers("two-levels-with-private"),
+  {}
+);
+
+testPrivate(
+  SETTINGS.twoLevelsWithPrivate,
+  [
+    {
+      default: "allow",
+      rules: [
+        {
+          from: [["helpers", { elementName: "helper-c" }]],
+          disallow: [["components", { category: "atoms", elementName: "*-a" }]],
+        },
+        {
+          from: [["helpers", { elementName: "helper-c" }]],
+          disallow: [["modules", { domain: "domain-a", elementName: "*-a" }]],
+        },
+        {
+          from: [["components", { category: "atoms" }]],
+          disallow: [["components", { category: "molecules" }]],
+        },
+        {
+          from: [["components", { category: "molecules" }]],
+          disallow: [["components", { category: "layouts" }]],
+        },
+        {
+          from: [["components", { category: "*" }]],
+          disallow: ["modules"],
+        },
+        {
+          from: [["modules", { domain: "pages" }]],
+          disallow: [["modules", { domain: "domain-a" }]],
+        },
+        {
+          from: [["modules", { domain: "pages" }]],
+          disallow: [["components", { category: "molecules" }]],
+        },
+        {
+          from: [["modules", { domain: "domain-a" }]],
+          disallow: [["components", { category: "molecules" }]],
+        },
+        {
+          from: [["modules", { domain: "domain-a" }]],
+          disallow: [["modules", { domain: "pages" }]],
+        },
+        {
+          from: [["modules", { domain: "domain-a" }]],
+          disallow: [["modules", { domain: "domain-b" }]],
+        },
+      ],
+    },
+  ],
+  pathResolvers("two-levels-with-private"),
+  {
+    0: "Importing elements of type 'components' with category 'atoms' and elementName '*-a' is not allowed in elements of type 'helpers' with elementName 'helper-c'. Disallowed in rule 1",
+    1: "Importing elements of type 'modules' with domain 'domain-a' and elementName '*-a' is not allowed in elements of type 'helpers' with elementName 'helper-c'. Disallowed in rule 2",
+    2: "Importing elements of type 'components' with category 'molecules' is not allowed in elements of type 'components' with category 'atoms'. Disallowed in rule 3",
+    3: "Importing elements of type 'components' with category 'molecules' is not allowed in elements of type 'components' with category 'atoms'. Disallowed in rule 3",
+    4: "Importing elements of type 'components' with category 'layouts' is not allowed in elements of type 'components' with category 'molecules'. Disallowed in rule 4",
+    5: "Importing elements of type 'modules' is not allowed in elements of type 'components' with category '*'. Disallowed in rule 5",
+    6: "Importing elements of type 'modules' is not allowed in elements of type 'components' with category '*'. Disallowed in rule 5",
+    7: "Importing elements of type 'components' with category 'molecules' is not allowed in elements of type 'modules' with domain 'pages'. Disallowed in rule 7",
+    8: "Importing elements of type 'modules' with domain 'domain-a' is not allowed in elements of type 'modules' with domain 'pages'. Disallowed in rule 6",
+    9: "Importing elements of type 'components' with category 'molecules' is not allowed in elements of type 'modules' with domain 'domain-a'. Disallowed in rule 8",
+    10: "Importing elements of type 'modules' with domain 'pages' is not allowed in elements of type 'modules' with domain 'domain-a'. Disallowed in rule 9",
+    11: "Importing elements of type 'modules' with domain 'domain-b' is not allowed in elements of type 'modules' with domain 'domain-a'. Disallowed in rule 10",
+  }
 );

--- a/test/rules/two-levels/element-types.spec.js
+++ b/test/rules/two-levels/element-types.spec.js
@@ -1,6 +1,6 @@
 const { ELEMENT_TYPES: RULE } = require("../../../src/constants/rules");
 const { SETTINGS, createRuleTester, pathResolvers } = require("../../support/helpers");
-const { elementTypesErrorMessage } = require("../../support/messages");
+const { elementTypesErrorMessage, elementTypesNoRuleMessage } = require("../../support/messages");
 
 const rule = require(`../../../src/rules/${RULE}`);
 
@@ -170,7 +170,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 0),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              0,
+              elementTypesNoRuleMessage({
+                file: "'helpers' with elementName 'helper-a'",
+                dep: "'components' with category 'atoms' and elementName 'atom-a'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -182,7 +189,15 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 1),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              1,
+              elementTypesNoRuleMessage({
+                file: "'helpers' with elementName 'helper-a'",
+                dep: "'modules' with domain 'domain-a' and elementName 'module-a'",
+              })
+            ),
+
             type: "ImportDeclaration",
           },
         ],
@@ -194,7 +209,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 2),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              2,
+              elementTypesNoRuleMessage({
+                file: "'components' with category 'atoms' and elementName 'atom-a'",
+                dep: "'components' with category 'molecules' and elementName 'molecule-a'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -206,7 +228,15 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 3),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              3,
+              elementTypesNoRuleMessage({
+                file: "'components' with category 'atoms' and elementName 'atom-a'",
+                dep: "'components' with category 'layouts' and elementName 'layout-a'",
+              })
+            ),
+
             type: "ImportDeclaration",
           },
         ],
@@ -218,7 +248,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 4),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              4,
+              elementTypesNoRuleMessage({
+                file: "'components' with category 'atoms' and elementName 'atom-a'",
+                dep: "'components' with category 'layouts' and elementName 'layout-a'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -230,7 +267,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 5),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              5,
+              elementTypesNoRuleMessage({
+                file: "'components' with category 'molecules' and elementName 'molecule-a'",
+                dep: "'components' with category 'layouts' and elementName 'layout-b'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -242,7 +286,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 6),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              6,
+              elementTypesNoRuleMessage({
+                file: "'components' with category 'molecules' and elementName 'molecule-a'",
+                dep: "'modules' with domain 'domain-a' and elementName 'module-a'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -254,7 +305,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 7),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              7,
+              elementTypesNoRuleMessage({
+                file: "'components' with category 'layouts' and elementName 'layout-a'",
+                dep: "'components' with category 'atoms' and elementName 'atom-a'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -266,7 +324,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 8),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              8,
+              elementTypesNoRuleMessage({
+                file: "'components' with category 'layouts' and elementName 'layout-a'",
+                dep: "'modules' with domain 'domain-a' and elementName 'module-a'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -278,7 +343,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 9),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              9,
+              elementTypesNoRuleMessage({
+                file: "'modules' with domain 'pages' and elementName 'page-a'",
+                dep: "'components' with category 'atoms' and elementName 'atom-b'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -290,7 +362,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 10),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              10,
+              elementTypesNoRuleMessage({
+                file: "'modules' with domain 'pages' and elementName 'page-a'",
+                dep: "'components' with category 'molecules' and elementName 'molecule-a'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -302,7 +381,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 11),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              11,
+              elementTypesNoRuleMessage({
+                file: "'modules' with domain 'pages' and elementName 'page-a'",
+                dep: "'modules' with domain 'pages' and elementName 'page-b'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -314,7 +400,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 12),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              12,
+              elementTypesNoRuleMessage({
+                file: "'modules' with domain 'pages' and elementName 'page-a'",
+                dep: "'modules' with domain 'domain-a' and elementName 'module-a'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -326,7 +419,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 13),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              13,
+              elementTypesNoRuleMessage({
+                file: "'modules' with domain 'pages' and elementName 'page-a'",
+                dep: "'modules' with domain 'domain-a' and elementName 'module-a'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -339,7 +439,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 14),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              14,
+              elementTypesNoRuleMessage({
+                file: "'modules' with domain 'domain-a' and elementName 'module-b'",
+                dep: "'components' with category 'atoms' and elementName 'atom-b'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -351,7 +458,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 15),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              15,
+              elementTypesNoRuleMessage({
+                file: "'modules' with domain 'domain-a' and elementName 'module-b'",
+                dep: "'components' with category 'atoms' and elementName 'atom-b'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -363,7 +477,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 16),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              16,
+              elementTypesNoRuleMessage({
+                file: "'modules' with domain 'domain-a' and elementName 'module-a'",
+                dep: "'components' with category 'molecules' and elementName 'molecule-a'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -375,7 +496,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 17),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              17,
+              elementTypesNoRuleMessage({
+                file: "'modules' with domain 'domain-a' and elementName 'module-a'",
+                dep: "'modules' with domain 'pages' and elementName 'page-b'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -387,7 +515,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 18),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              18,
+              elementTypesNoRuleMessage({
+                file: "'modules' with domain 'domain-a' and elementName 'module-a'",
+                dep: "'modules' with domain 'domain-b' and elementName 'module-a'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -399,7 +534,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 19),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              19,
+              elementTypesNoRuleMessage({
+                file: "'modules' with domain 'domain-a' and elementName 'module-a'",
+                dep: "'modules' with domain 'domain-b' and elementName 'module-b'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -411,7 +553,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 20),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              20,
+              elementTypesNoRuleMessage({
+                file: "'modules' with domain 'domain-b' and elementName 'module-a'",
+                dep: "'components' with category 'layouts' and elementName 'layout-a'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -423,7 +572,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 21),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              21,
+              elementTypesNoRuleMessage({
+                file: "'modules' with domain 'domain-b' and elementName 'module-a'",
+                dep: "'components' with category 'molecules' and elementName 'molecule-a'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -435,7 +591,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 22),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              22,
+              elementTypesNoRuleMessage({
+                file: "'modules' with domain 'domain-b' and elementName 'module-a'",
+                dep: "'modules' with domain 'pages' and elementName 'page-a'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -447,7 +610,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 23),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              23,
+              elementTypesNoRuleMessage({
+                file: "'modules' with domain 'domain-b' and elementName 'module-a'",
+                dep: "'components' with category 'atoms' and elementName 'atom-a'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -459,7 +629,14 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 24),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              24,
+              elementTypesNoRuleMessage({
+                file: "'modules' with domain 'domain-a' and elementName 'module-a'",
+                dep: "'components' with category 'atoms' and elementName 'atom-a'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -584,7 +761,14 @@ const testPrivate = (settings, options, { absoluteFilePath }, errorMessages) => 
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 0),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              0,
+              elementTypesNoRuleMessage({
+                file: "'helpers' with elementName 'helper-c'",
+                dep: "'components' with category 'atoms' and elementName 'atom-a'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -596,7 +780,14 @@ const testPrivate = (settings, options, { absoluteFilePath }, errorMessages) => 
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 1),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              1,
+              elementTypesNoRuleMessage({
+                file: "'helpers' with elementName 'helper-c'",
+                dep: "'modules' with domain 'domain-a' and elementName 'module-a'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -608,7 +799,14 @@ const testPrivate = (settings, options, { absoluteFilePath }, errorMessages) => 
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 2),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              2,
+              elementTypesNoRuleMessage({
+                file: "'components' with category 'atoms' and elementName 'atom-a'",
+                dep: "'components' with category 'molecules' and elementName 'molecule-c'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -620,7 +818,14 @@ const testPrivate = (settings, options, { absoluteFilePath }, errorMessages) => 
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 3),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              3,
+              elementTypesNoRuleMessage({
+                file: "'components' with category 'atoms' and elementName 'atom-a'",
+                dep: "'components' with category 'molecules' and elementName 'molecule-d'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -634,7 +839,14 @@ const testPrivate = (settings, options, { absoluteFilePath }, errorMessages) => 
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 4),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              4,
+              elementTypesNoRuleMessage({
+                file: "'components' with category 'molecules' and elementName 'molecule-c'",
+                dep: "'components' with category 'layouts' and elementName 'layout-b'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -648,7 +860,14 @@ const testPrivate = (settings, options, { absoluteFilePath }, errorMessages) => 
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 5),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              5,
+              elementTypesNoRuleMessage({
+                file: "'components' with category 'molecules' and elementName 'molecule-c'",
+                dep: "'modules' with domain 'domain-a' and elementName 'module-a'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -660,7 +879,14 @@ const testPrivate = (settings, options, { absoluteFilePath }, errorMessages) => 
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 6),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              6,
+              elementTypesNoRuleMessage({
+                file: "'components' with category 'layouts' and elementName 'layout-a'",
+                dep: "'modules' with domain 'domain-a', ancestorsPaths 'module-a' and elementName 'module-c'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -672,7 +898,14 @@ const testPrivate = (settings, options, { absoluteFilePath }, errorMessages) => 
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 7),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              7,
+              elementTypesNoRuleMessage({
+                file: "'modules' with domain 'pages' and elementName 'page-a'",
+                dep: "'components' with category 'molecules' and elementName 'molecule-c'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -684,7 +917,14 @@ const testPrivate = (settings, options, { absoluteFilePath }, errorMessages) => 
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 8),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              8,
+              elementTypesNoRuleMessage({
+                file: "'modules' with domain 'pages' and elementName 'page-a'",
+                dep: "'modules' with domain 'domain-a', ancestorsPaths 'module-a' and elementName 'module-c'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -696,7 +936,14 @@ const testPrivate = (settings, options, { absoluteFilePath }, errorMessages) => 
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 9),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              9,
+              elementTypesNoRuleMessage({
+                file: "'modules' with domain 'domain-a', ancestorsPaths 'module-a' and elementName 'module-c'",
+                dep: "'components' with category 'molecules' and elementName 'molecule-c'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -708,7 +955,14 @@ const testPrivate = (settings, options, { absoluteFilePath }, errorMessages) => 
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 10),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              10,
+              elementTypesNoRuleMessage({
+                file: "'modules' with domain 'domain-a', ancestorsPaths 'module-a' and elementName 'module-c'",
+                dep: "'modules' with domain 'pages' and elementName 'page-b'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -720,7 +974,14 @@ const testPrivate = (settings, options, { absoluteFilePath }, errorMessages) => 
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(errorMessages, 11),
+            message: elementTypesErrorMessage(
+              errorMessages,
+              11,
+              elementTypesNoRuleMessage({
+                file: "'modules' with domain 'domain-a', ancestorsPaths 'module-a' and elementName 'module-c'",
+                dep: "'modules' with domain 'domain-b' and elementName 'module-a'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],

--- a/test/support/messages.js
+++ b/test/support/messages.js
@@ -1,12 +1,9 @@
-const ELEMENT_TYPES_DEFAULT_MESSAGE =
-  "Importing elements is disallowed by default. No rule allowing this dependency was found";
-
 function errorMessage(errors, index, defaultMessage) {
   return errors[index] || defaultMessage;
 }
 
 function elementTypesErrorMessage(errors, index, defaultMessage) {
-  return errorMessage(errors, index, defaultMessage || ELEMENT_TYPES_DEFAULT_MESSAGE);
+  return errorMessage(errors, index, defaultMessage);
 }
 
 function elementTypesNoRuleMessage({ file, dep }) {
@@ -14,7 +11,6 @@ function elementTypesNoRuleMessage({ file, dep }) {
 }
 
 module.exports = {
-  ELEMENT_TYPES_DEFAULT_MESSAGE,
   elementTypesErrorMessage,
   elementTypesNoRuleMessage,
 };

--- a/test/support/messages.js
+++ b/test/support/messages.js
@@ -1,0 +1,15 @@
+const ELEMENT_TYPES_DEFAULT_MESSAGE =
+  "Importing elements is disallowed by default. No rule allowing this dependency was found";
+
+function errorMessage(errors, index, defaultMessage) {
+  return errors[index] || defaultMessage;
+}
+
+function elementTypesErrorMessage(errors, index) {
+  return errorMessage(errors, index, ELEMENT_TYPES_DEFAULT_MESSAGE);
+}
+
+module.exports = {
+  ELEMENT_TYPES_DEFAULT_MESSAGE,
+  elementTypesErrorMessage,
+};

--- a/test/support/messages.js
+++ b/test/support/messages.js
@@ -5,11 +5,16 @@ function errorMessage(errors, index, defaultMessage) {
   return errors[index] || defaultMessage;
 }
 
-function elementTypesErrorMessage(errors, index) {
-  return errorMessage(errors, index, ELEMENT_TYPES_DEFAULT_MESSAGE);
+function elementTypesErrorMessage(errors, index, defaultMessage) {
+  return errorMessage(errors, index, defaultMessage || ELEMENT_TYPES_DEFAULT_MESSAGE);
+}
+
+function elementTypesNoRuleMessage({ file, dep }) {
+  return `No rule allowing this dependency was found. File is of type ${file}. Dependency is of type ${dep}`;
 }
 
 module.exports = {
   ELEMENT_TYPES_DEFAULT_MESSAGE,
   elementTypesErrorMessage,
+  elementTypesNoRuleMessage,
 };


### PR DESCRIPTION
### Added
- feat(#87): Support custom messages in `element-types` config

### Changed
- feat(#87): Add context about the specific rule forbidding the import to the `element-types` error message. Add information about file and dependency when import is forbidden due to the default configuration.
- refactor: Add isArray and isString utils

### Fixed
- fix: Support array of micromatch patterns when replacing captured values
- docs: Fix broken links

### Removed
- feat: Remove cache traces from debug mode