### PR TITLE
Custom messages in `entry-point` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 ### BREAKING CHANGES
 
+## [unreleased]
+
+### Added
+- feat(#169): Support custom messages in `entry-point` rule config
+
+### Fixed
+- docs: Fix some typos and links in `element-types` rule docs
+
 ## [2.6.0] - 2021-11-13
 
 ### Added
-- feat(#87): Support custom messages in `element-types` config
+- feat(#87): Support custom messages in `element-types` rule config
 
 ### Changed
 - feat(#87): Add context about the specific rule forbidding the import to the `element-types` error message. Add information about file and dependency when import is forbidden due to the default configuration.

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Some rules require extra configuration, and it has to be defined in each specifi
 
 #### Main format of rules options
 
-The docs of each rule contains an specification of their own options, but __the main rules share the format in which the options have to be defined__. The format described here is valid for options of [`element-types`](docs/rules/element-types.md), [`external`](docs/rules/external.md) and [`entry-point`](docs/rules/entry-point.md) rules, __except the `message` properties, which for the moment are only supported in the [`element-types`](docs/rules/element-types.md) rule settings.
+The docs of each rule contains an specification of their own options, but __the main rules share the format in which the options have to be defined__. The format described here is valid for options of [`element-types`](docs/rules/element-types.md), [`external`](docs/rules/external.md) and [`entry-point`](docs/rules/entry-point.md) rules, __except the `message` property, which for the moment is only supported in the [`element-types`](docs/rules/element-types.md) and [`entry-point`](docs/rules/entry-point.md) rules settings.
 
 Options set an "allow/disallow" value by default, and provide an array of rules. Each matching rule will override the default value and the value returned by previous matching rules. So, the final result of the options, once processed for each case, will be "allow" or "disallow", and this value will be applied by the plugin rule in the correspondant way, making it to produce an eslint error or not.
 
@@ -300,7 +300,7 @@ Remember that:
 
 * __`from/target`__: `<element matchers>` Depending of the rule to which the options are for, the rule will be applied only if the file being analized matches with this element matcher (`from`), or the dependency being imported matches with this element matcher (`target`).
 * __`disallow/allow`__: `<value matchers>` If the plugin rule target matches with this, then the result of the rule will be "disallow/allow". Each rule will require a type of value here depending of what it is checking. In the case of the `element-types` rule, for example, another `<element matcher>` has to be provided in order to check the type of the local dependency.
-* __`message`__: `<string>` Optional. If the rule results in an error, the plugin will return this message.
+* __`message`__: `<string>` Optional. If the rule results in an error, the plugin will return this message instead of the default one. Read [error messages](#error-messages) for further info.
 
 > Tip: Properties `from/target` and `disallow/allow` can receive a single matcher, or an array of matchers.
 
@@ -317,7 +317,7 @@ Elements matchers used in the rules options can have the next formats:
 
 The plugin returns a different default message for each rule, check the documentation of each one for further info. But some rules support defining custom messages in their configuration, as seen in ["Main format of rules options"](#main-format-of-rules-options).
 
-When defining custom messages, it is possible to provide information about the type or captured properties of the current file or dependency. Use `${file.PROPERTY}` or `${dependency.PROPERTY}`, and it will be replaced by the correspondent captured value from the file or the dependency:
+When defining custom messages, it is possible to provide information about the current file or dependency. Use `${file.PROPERTY}` or `${dependency.PROPERTY}`, and it will be replaced by the correspondent captured value from the file or the dependency:
 
 ```jsonc
 {
@@ -326,6 +326,13 @@ When defining custom messages, it is possible to provide information about the t
   // "components of category atom are not allowed to import molecules"
 }
 ```
+
+Available properties in error templates both from `file` or `dependency` are:
+
+* `type`: Element's type.
+* `internalPath`: File path being analyzed or imported. Relative to the element's root path.
+* ...All captured properties are also available
+
 
 > Tip: Read ["Global settings"](#global-settings) for further info about how to capture values from elements.
 

--- a/docs/rules/element-types.md
+++ b/docs/rules/element-types.md
@@ -19,11 +19,7 @@ It checks `import` statements between the element types of the project based on 
   * `from`: `<element matchers>` If the file being analyzed matches with this, then the rule will be executed to know if it allows/disallows the `import`. If not, the rule is skipped.
   * `disallow`: `<element matchers>` If the element being imported matches with this, then the result of the rule will be "disallow", and the import will be notified as an `eslint` error (this value can be overwritten by a next rule returning "allow")
   * `allow`: `<element matchers>` If the element being imported matches with this, then the result of the rule will be "allow", and the import will not be notified as an `eslint` error (this value can be overwritten by a next rule returning "disallow")
-  * `message`: `<string>` Custom error message only for this rule. Read ["error messages"](../../README.md#error-messages) for further info.
-
-##### Further reading:
-* [Main format of rules options](../../README.md#main-format-of-rules-options)
-* [Element matchers](../../README.md#elements-matchers)
+  * `message`: `<string>` Custom error message only for this rule. Read ["error messages"](#error-messages) for further info.
 
 ##### Comparing captures of the file element with captures of the imported element
 
@@ -80,15 +76,6 @@ So, if the `from` element has captured values `{ family: "atom", elementName: "c
   }
 }
 ```
-
-### Error messages
-
-This rule provides a lot of information about the specific option producing an error, so the user can have enough context to solve it.
-
-* If the error is produced because all imports are disallowed by default, and no rule is specificly allowing it, then the message provides information about the file and the dependency types and captured values: `No rule allowing this dependency was found. File is of type 'components' with category 'molecules' and elementName 'molecule-c'. Dependency is of type 'modules' with domain 'domain-a' and elementName 'module-a'`.
-* If the error is produced by a specific option, the the message includes information about the option producing it: `Importing elements of type 'components' with category 'atoms' and elementName '*-a' is not allowed in elements of type 'helpers' with elementName 'helper-c'. Disallowed in rule 1`
-
-Anyway, you can configure a custom error message for changing this behaviour, or even custom error messages only for a specific rule option. Read ["error messages"](../../README.md#error-messages) for further info about how to configure messages.
 
 ### Settings
 
@@ -245,6 +232,15 @@ _Modules can import another modules:_
 // src/modules/module-a/ModuleA.js
 import ModuleB from 'modules/module-b'
 ```
+
+### Error messages
+
+This rule provides a lot of information about the specific option producing an error, so the user can have enough context to solve it.
+
+* If the error is produced because all imports are disallowed by default, and no rule is specificly allowing it, then the message provides information about the file and the dependency types and captured values: `No rule allowing this dependency was found. File is of type 'components' with category 'molecules' and elementName 'molecule-c'. Dependency is of type 'modules' with domain 'domain-a' and elementName 'module-a'`.
+* If the error is produced by a specific option, then the message includes information about the option producing it: `Importing elements of type 'components' with category 'atoms' and elementName '*-a' is not allowed in elements of type 'helpers' with elementName 'helper-c'. Disallowed in rule 1`
+
+You can also configure a custom error message for changing this default behaviour, or even custom error messages only for a specific rule option. Read ["error messages"](../../README.md#error-messages) in the main docs for further info about how to configure messages.
 
 ## Further reading
 

--- a/docs/rules/entry-point.md
+++ b/docs/rules/entry-point.md
@@ -14,14 +14,12 @@ It checks `import` statements to the elements of the project and ensure that eac
 
 * `enabled`: for enabling the rule. 0=off, 1=warn, 2=error.
 * `default`: `allow` or `disallow`. If no one `rule` matches, the dependency will be allowed or disallowed based on this value.
+* `message`: Custom message for the rule errors. Note that __the rule default message provides a lot of information about why the error was produced__, so you should define a custom message only if you are sure about what you are doing. Read ["error messages"](#error-messages) for further information.
 * `rules`: Rules to be processed in order to decide if the `import` statement has to be allowed or not.
   * `target`: `<element matchers>` If the element being imported matches with this, then the rule will be executed to know if it allows/disallows the `import`. If not, the rule is skipped.
   * `disallow`: `<string>` A [`micromatch` pattern](https://github.com/micromatch/micromatch). If the element being imported matches with this, then the result of the rule will be "disallow", and the import will be notified as an `eslint` error (this value can be overwritten by a next rule returning "allow")
   * `allow`: `<string>` A [`micromatch` pattern](https://github.com/micromatch/micromatch). If the element being imported matches with this, then the result of the rule will be "allow", and the import will not be notified as an `eslint` error (this value can be overwritten by a next rule returning "disallow")
-
-##### Further reading:
-* [Main format of rules options](../../README.md#main-format-of-rules-options)
-* [Element matchers](../../README.md#elements-matchers)
+  * `message`: `<string>` Custom error message only for this rule. Read ["error messages"](#error-messages) for further info.
 
 ##### Options example
 
@@ -169,6 +167,15 @@ _index.js from modules can be imported:_
 import ModuleB from 'modules/module-b'
 
 ```
+
+### Error messages
+
+This rule provides a lot of information about the specific option producing an error, so the user can have enough context to solve it.
+
+* If the error is produced because all entry points are disallowed by default, and no rule is specificly allowing it, then the message provides information about the dependency type and captured values: `No rule allows the entry point 'fooFile.js' in dependencies of type 'components' with category 'molecules' and elementName 'molecule-c'`.
+* If the error is produced by a specific option, then the message includes information about the option producing it: `The entry point 'fooFile.js' is not allowed in elements of type 'helpers' with elementName 'helper-c'. Disallowed in rule 2`
+
+You can also configure a custom error message for changing this default behaviour, or even custom error messages only for a specific rule option. Read ["error messages"](../../README.md#error-messages) in the main docs for further info about how to configure messages.
 
 ## Further reading
 

--- a/src/helpers/messages.js
+++ b/src/helpers/messages.js
@@ -82,7 +82,7 @@ function ruleElementMessage(elementPatterns, elementCapturedValues) {
 function customErrorMessage(message, file, dependency) {
   return replaceObjectValuesInTemplates(
     replaceObjectValuesInTemplates(message, { ...file.capturedValues, type: file.type }, "file"),
-    { ...dependency.capturedValues, type: dependency.type },
+    { ...dependency.capturedValues, type: dependency.type, internalPath: dependency.internalPath },
     "dependency"
   );
 }

--- a/src/rules/entry-point.js
+++ b/src/rules/entry-point.js
@@ -20,7 +20,11 @@ function elementRulesAllowEntryPoint(element, dependency, options) {
     options,
     isMatch: isMatchElementInternalPath,
     rulesMainKey: "target",
-  }).result;
+  });
+}
+
+function errorMessage(ruleData, file, dependency) {
+  return `Entry point '${dependency.internalPath}' is not allowed in '${dependency.type}'`;
 }
 
 module.exports = dependencyRule(
@@ -32,17 +36,15 @@ module.exports = dependencyRule(
     }),
   },
   function ({ dependency, file, node, context, options }) {
-    if (
-      !dependency.isIgnored &&
-      dependency.type &&
-      !dependency.isInternal &&
-      !elementRulesAllowEntryPoint(file, dependency, options)
-    ) {
-      context.report({
-        message: `Entry point '${dependency.internalPath}' is not allowed in '${dependency.type}'`,
-        node: node,
-        ...dependencyLocation(node, context),
-      });
+    if (!dependency.isIgnored && dependency.type && !dependency.isInternal) {
+      const ruleData = elementRulesAllowEntryPoint(file, dependency, options);
+      if (!ruleData.result) {
+        context.report({
+          message: errorMessage(ruleData, file, dependency),
+          node: node,
+          ...dependencyLocation(node, context),
+        });
+      }
     }
   },
   {

--- a/test/rules/docs-examples/entry-point.spec.js
+++ b/test/rules/docs-examples/entry-point.spec.js
@@ -1,12 +1,10 @@
 const { ENTRY_POINT: RULE } = require("../../../src/constants/rules");
 const { SETTINGS, createRuleTester, pathResolvers } = require("../../support/helpers");
+const { customErrorMessage, entryPointNoRuleMessage } = require("../../support/messages");
 
 const rule = require(`../../../src/rules/${RULE}`);
 
 const { absoluteFilePath } = pathResolvers("docs-examples");
-
-const errorMessage = (disallowedEntryPoint, type) =>
-  `Entry point '${disallowedEntryPoint}' is not allowed in '${type}'`;
 
 const settings = SETTINGS.docsExamples;
 
@@ -30,6 +28,8 @@ const options = [
     ],
   },
 ];
+
+const errorMessages = {};
 
 const ruleTester = createRuleTester(settings);
 
@@ -68,7 +68,14 @@ ruleTester.run(RULE, rule, {
       options,
       errors: [
         {
-          message: errorMessage("AtomA.js", "components"),
+          message: customErrorMessage(
+            errorMessages,
+            0,
+            entryPointNoRuleMessage({
+              entryPoint: "AtomA.js",
+              dep: "'components' with family 'atoms' and elementName 'atom-a'",
+            })
+          ),
           type: "ImportDeclaration",
         },
       ],
@@ -80,7 +87,14 @@ ruleTester.run(RULE, rule, {
       options,
       errors: [
         {
-          message: errorMessage("ModuleB.js", "modules"),
+          message: customErrorMessage(
+            errorMessages,
+            1,
+            entryPointNoRuleMessage({
+              entryPoint: "ModuleB.js",
+              dep: "'modules' with elementName 'module-b'",
+            })
+          ),
           type: "ImportDeclaration",
         },
       ],

--- a/test/rules/nestjs-example/element-types.spec.js
+++ b/test/rules/nestjs-example/element-types.spec.js
@@ -1,6 +1,6 @@
 const { ELEMENT_TYPES: RULE } = require("../../../src/constants/rules");
 const { createRuleTester, pathResolvers } = require("../../support/helpers");
-const { elementTypesErrorMessage, elementTypesNoRuleMessage } = require("../../support/messages");
+const { customErrorMessage, elementTypesNoRuleMessage } = require("../../support/messages");
 
 const rule = require(`../../../src/rules/${RULE}`);
 
@@ -108,7 +108,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages, base) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               0,
               elementTypesNoRuleMessage({
@@ -127,7 +127,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages, base) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               1,
               elementTypesNoRuleMessage({
@@ -146,7 +146,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages, base) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               2,
               elementTypesNoRuleMessage({
@@ -165,7 +165,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages, base) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               3,
               elementTypesNoRuleMessage({
@@ -184,7 +184,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages, base) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               4,
               elementTypesNoRuleMessage({
@@ -203,7 +203,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages, base) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               5,
               elementTypesNoRuleMessage({
@@ -222,7 +222,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages, base) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               6,
               elementTypesNoRuleMessage({
@@ -241,7 +241,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages, base) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               7,
               elementTypesNoRuleMessage({
@@ -260,7 +260,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages, base) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               8,
               elementTypesNoRuleMessage({
@@ -279,7 +279,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages, base) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               9,
               elementTypesNoRuleMessage({
@@ -298,7 +298,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages, base) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               10,
               elementTypesNoRuleMessage({
@@ -317,7 +317,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages, base) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               11,
               elementTypesNoRuleMessage({
@@ -336,7 +336,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages, base) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               12,
               elementTypesNoRuleMessage({

--- a/test/rules/one-level/element-types.spec.js
+++ b/test/rules/one-level/element-types.spec.js
@@ -1,6 +1,6 @@
 const { ELEMENT_TYPES: RULE } = require("../../../src/constants/rules");
 const { SETTINGS, createRuleTester, pathResolvers } = require("../../support/helpers");
-const { elementTypesErrorMessage, elementTypesNoRuleMessage } = require("../../support/messages");
+const { customErrorMessage, elementTypesNoRuleMessage } = require("../../support/messages");
 
 const rule = require(`../../../src/rules/${RULE}`);
 
@@ -178,7 +178,7 @@ const test = (settings, options, errorMessages) => {
         ],
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               0,
               elementTypesNoRuleMessage({
@@ -197,7 +197,7 @@ const test = (settings, options, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               1,
               elementTypesNoRuleMessage({
@@ -216,7 +216,7 @@ const test = (settings, options, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               2,
               elementTypesNoRuleMessage({
@@ -235,7 +235,7 @@ const test = (settings, options, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               3,
               elementTypesNoRuleMessage({
@@ -254,7 +254,7 @@ const test = (settings, options, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               4,
               elementTypesNoRuleMessage({
@@ -314,7 +314,7 @@ const testCapture = (settings, options, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               0,
               elementTypesNoRuleMessage({
@@ -333,7 +333,7 @@ const testCapture = (settings, options, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               1,
               elementTypesNoRuleMessage({
@@ -352,7 +352,7 @@ const testCapture = (settings, options, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               2,
               elementTypesNoRuleMessage({
@@ -371,7 +371,7 @@ const testCapture = (settings, options, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               3,
               elementTypesNoRuleMessage({

--- a/test/rules/one-level/entry-point.spec.js
+++ b/test/rules/one-level/entry-point.spec.js
@@ -1,12 +1,10 @@
 const { ENTRY_POINT: RULE } = require("../../../src/constants/rules");
 const { SETTINGS, createRuleTester, pathResolvers } = require("../../support/helpers");
+const { customErrorMessage, entryPointNoRuleMessage } = require("../../support/messages");
 
 const rule = require(`../../../src/rules/${RULE}`);
 
 const { absoluteFilePath, codeFilePath } = pathResolvers("one-level");
-
-const errorMessage = (disallowedEntryPoint, type) =>
-  `Entry point '${disallowedEntryPoint}' is not allowed in '${type}'`;
 
 const defaultOptions = [
   {
@@ -20,7 +18,7 @@ const defaultOptions = [
   },
 ];
 
-const test = (settings, options) => {
+const test = (settings, options, errorMessages = {}) => {
   const ruleTester = createRuleTester(settings);
   ruleTester.run(RULE, rule, {
     valid: [
@@ -94,7 +92,14 @@ const test = (settings, options) => {
         options: defaultOptions,
         errors: [
           {
-            message: errorMessage("ComponentB.js", "components"),
+            message: customErrorMessage(
+              errorMessages,
+              0,
+              entryPointNoRuleMessage({
+                entryPoint: "ComponentB.js",
+                dep: "'components' with elementName 'component-b'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -106,7 +111,14 @@ const test = (settings, options) => {
         options,
         errors: [
           {
-            message: errorMessage("index.js", "helpers"),
+            message: customErrorMessage(
+              errorMessages,
+              1,
+              entryPointNoRuleMessage({
+                entryPoint: "index.js",
+                dep: "'helpers' with elementName 'helper-a'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -118,7 +130,14 @@ const test = (settings, options) => {
         options,
         errors: [
           {
-            message: errorMessage("index.js", "helpers"),
+            message: customErrorMessage(
+              errorMessages,
+              2,
+              entryPointNoRuleMessage({
+                entryPoint: "index.js",
+                dep: "'helpers' with elementName 'helper-a'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -130,7 +149,14 @@ const test = (settings, options) => {
         options,
         errors: [
           {
-            message: errorMessage("main.js", "components"),
+            message: customErrorMessage(
+              errorMessages,
+              3,
+              entryPointNoRuleMessage({
+                entryPoint: "main.js",
+                dep: "'components' with elementName 'component-b'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -139,7 +165,7 @@ const test = (settings, options) => {
   });
 };
 
-const testCapture = (settings, options) => {
+const testCapture = (settings, options, errorMessages = {}) => {
   const ruleTester = createRuleTester(settings);
   ruleTester.run(RULE, rule, {
     valid: [
@@ -164,7 +190,14 @@ const testCapture = (settings, options) => {
         options,
         errors: [
           {
-            message: errorMessage("index.js", "helpers"),
+            message: customErrorMessage(
+              errorMessages,
+              0,
+              entryPointNoRuleMessage({
+                entryPoint: "index.js",
+                dep: "'helpers' with elementName 'helper-b'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -176,7 +209,14 @@ const testCapture = (settings, options) => {
         options,
         errors: [
           {
-            message: errorMessage("main.js", "helpers"),
+            message: customErrorMessage(
+              errorMessages,
+              1,
+              entryPointNoRuleMessage({
+                entryPoint: "main.js",
+                dep: "'helpers' with elementName 'helper-a'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -253,64 +293,118 @@ test(SETTINGS.oneLevel, [
 
 // redundant options
 
-test(SETTINGS.oneLevel, [
+test(
+  SETTINGS.oneLevel,
+  [
+    {
+      default: "allow",
+      rules: [
+        {
+          target: "helpers",
+          disallow: "*.js",
+        },
+        {
+          target: "helpers",
+          allow: "main.js",
+        },
+        {
+          target: "components",
+          disallow: "*.js",
+        },
+        {
+          target: "components",
+          allow: "Component.js",
+        },
+        {
+          target: "modules",
+          disallow: "*",
+        },
+        {
+          target: "modules",
+          allow: "Module.js",
+        },
+      ],
+    },
+  ],
   {
-    default: "allow",
-    rules: [
-      {
-        target: "helpers",
-        disallow: "*.js",
-      },
-      {
-        target: "helpers",
-        allow: "main.js",
-      },
-      {
-        target: "components",
-        disallow: "*.js",
-      },
-      {
-        target: "components",
-        allow: "Component.js",
-      },
-      {
-        target: "modules",
-        disallow: "*",
-      },
-      {
-        target: "modules",
-        allow: "Module.js",
-      },
-    ],
-  },
-]);
+    1: "The entry point 'index.js' is not allowed in elements of type 'helpers'. Disallowed in rule 1",
+    2: "The entry point 'index.js' is not allowed in elements of type 'helpers'. Disallowed in rule 1",
+    3: "The entry point 'main.js' is not allowed in elements of type 'components'. Disallowed in rule 3",
+  }
+);
 
 // options with capture
 
-testCapture(SETTINGS.oneLevel, [
+testCapture(
+  SETTINGS.oneLevel,
+  [
+    {
+      default: "disallow",
+      rules: [
+        {
+          target: "helpers",
+          allow: "main.js",
+        },
+        {
+          target: [["helpers", { elementName: "*-a" }]],
+          disallow: "*",
+        },
+        {
+          target: [["helpers", { elementName: "*-a" }]],
+          allow: "index.*",
+        },
+        {
+          target: "components",
+          allow: "Component.js",
+        },
+        {
+          target: "modules",
+          allow: "Module.js",
+        },
+      ],
+    },
+  ],
   {
-    default: "disallow",
-    rules: [
-      {
-        target: "helpers",
-        allow: "main.js",
-      },
-      {
-        target: [["helpers", { elementName: "*-a" }]],
-        disallow: "*",
-      },
-      {
-        target: [["helpers", { elementName: "*-a" }]],
-        allow: "index.*",
-      },
-      {
-        target: "components",
-        allow: "Component.js",
-      },
-      {
-        target: "modules",
-        allow: "Module.js",
-      },
-    ],
-  },
-]);
+    1: "The entry point 'main.js' is not allowed in elements of type 'helpers' with elementName '*-a'. Disallowed in rule 2",
+  }
+);
+
+// Custom messages
+
+testCapture(
+  SETTINGS.oneLevel,
+  [
+    {
+      default: "disallow",
+      message:
+        "Importing the file ${dependency.internalPath} is not allowed in ${dependency.type}",
+      rules: [
+        {
+          target: "helpers",
+          allow: "main.js",
+        },
+        {
+          target: [["helpers", { elementName: "*-a" }]],
+          disallow: "*",
+          message: "Do not import any type of file from helpers with name *-a",
+        },
+        {
+          target: [["helpers", { elementName: "*-a" }]],
+          allow: "index.*",
+        },
+        {
+          target: "components",
+          allow: "Component.js",
+        },
+        {
+          target: "modules",
+          allow: "Module.js",
+        },
+      ],
+    },
+  ],
+  {
+    0: "Importing the file index.js is not allowed in helpers",
+    1: "Do not import any type of file from helpers with name *-a",
+  }
+);

--- a/test/rules/one-level/entry-point.spec.js
+++ b/test/rules/one-level/entry-point.spec.js
@@ -45,6 +45,16 @@ const test = (settings, options) => {
           "boundaries/ignore": [codeFilePath("helpers/helper-b/**/*.js")],
         },
       },
+      // Files can import ignored dependencies
+      {
+        filename: absoluteFilePath("helpers/helper-b/HelperB.js"),
+        code: "import HelperA from 'helpers/helper-a/HelperA.js'",
+        options,
+        settings: {
+          ...settings,
+          "boundaries/ignore": [codeFilePath("helpers/helper-a/**/*.js")],
+        },
+      },
       // import index with default option
       {
         filename: absoluteFilePath("components/component-a/ComponentA.js"),

--- a/test/rules/one-level/invalid-settings.spec.js
+++ b/test/rules/one-level/invalid-settings.spec.js
@@ -1,6 +1,6 @@
 const { ELEMENT_TYPES: RULE } = require("../../../src/constants/rules");
 const { SETTINGS, createRuleTester, pathResolvers } = require("../../support/helpers");
-const { elementTypesErrorMessage, elementTypesNoRuleMessage } = require("../../support/messages");
+const { customErrorMessage, elementTypesNoRuleMessage } = require("../../support/messages");
 
 const rule = require(`../../../src/rules/${RULE}`);
 
@@ -60,7 +60,7 @@ const test = (settings, options, errorMessages) => {
         ],
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               0,
               elementTypesNoRuleMessage({

--- a/test/rules/two-levels/element-types.spec.js
+++ b/test/rules/two-levels/element-types.spec.js
@@ -1,6 +1,6 @@
 const { ELEMENT_TYPES: RULE } = require("../../../src/constants/rules");
 const { SETTINGS, createRuleTester, pathResolvers } = require("../../support/helpers");
-const { elementTypesErrorMessage, elementTypesNoRuleMessage } = require("../../support/messages");
+const { customErrorMessage, elementTypesNoRuleMessage } = require("../../support/messages");
 
 const rule = require(`../../../src/rules/${RULE}`);
 
@@ -170,7 +170,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               0,
               elementTypesNoRuleMessage({
@@ -189,7 +189,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               1,
               elementTypesNoRuleMessage({
@@ -209,7 +209,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               2,
               elementTypesNoRuleMessage({
@@ -228,7 +228,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               3,
               elementTypesNoRuleMessage({
@@ -248,7 +248,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               4,
               elementTypesNoRuleMessage({
@@ -267,7 +267,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               5,
               elementTypesNoRuleMessage({
@@ -286,7 +286,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               6,
               elementTypesNoRuleMessage({
@@ -305,7 +305,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               7,
               elementTypesNoRuleMessage({
@@ -324,7 +324,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               8,
               elementTypesNoRuleMessage({
@@ -343,7 +343,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               9,
               elementTypesNoRuleMessage({
@@ -362,7 +362,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               10,
               elementTypesNoRuleMessage({
@@ -381,7 +381,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               11,
               elementTypesNoRuleMessage({
@@ -400,7 +400,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               12,
               elementTypesNoRuleMessage({
@@ -419,7 +419,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               13,
               elementTypesNoRuleMessage({
@@ -439,7 +439,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               14,
               elementTypesNoRuleMessage({
@@ -458,7 +458,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               15,
               elementTypesNoRuleMessage({
@@ -477,7 +477,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               16,
               elementTypesNoRuleMessage({
@@ -496,7 +496,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               17,
               elementTypesNoRuleMessage({
@@ -515,7 +515,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               18,
               elementTypesNoRuleMessage({
@@ -534,7 +534,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               19,
               elementTypesNoRuleMessage({
@@ -553,7 +553,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               20,
               elementTypesNoRuleMessage({
@@ -572,7 +572,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               21,
               elementTypesNoRuleMessage({
@@ -591,7 +591,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               22,
               elementTypesNoRuleMessage({
@@ -610,7 +610,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               23,
               elementTypesNoRuleMessage({
@@ -629,7 +629,7 @@ const test = (settings, options, { absoluteFilePath }, errorMessages) => {
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               24,
               elementTypesNoRuleMessage({
@@ -761,7 +761,7 @@ const testPrivate = (settings, options, { absoluteFilePath }, errorMessages) => 
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               0,
               elementTypesNoRuleMessage({
@@ -780,7 +780,7 @@ const testPrivate = (settings, options, { absoluteFilePath }, errorMessages) => 
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               1,
               elementTypesNoRuleMessage({
@@ -799,7 +799,7 @@ const testPrivate = (settings, options, { absoluteFilePath }, errorMessages) => 
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               2,
               elementTypesNoRuleMessage({
@@ -818,7 +818,7 @@ const testPrivate = (settings, options, { absoluteFilePath }, errorMessages) => 
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               3,
               elementTypesNoRuleMessage({
@@ -839,7 +839,7 @@ const testPrivate = (settings, options, { absoluteFilePath }, errorMessages) => 
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               4,
               elementTypesNoRuleMessage({
@@ -860,7 +860,7 @@ const testPrivate = (settings, options, { absoluteFilePath }, errorMessages) => 
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               5,
               elementTypesNoRuleMessage({
@@ -879,7 +879,7 @@ const testPrivate = (settings, options, { absoluteFilePath }, errorMessages) => 
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               6,
               elementTypesNoRuleMessage({
@@ -898,7 +898,7 @@ const testPrivate = (settings, options, { absoluteFilePath }, errorMessages) => 
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               7,
               elementTypesNoRuleMessage({
@@ -917,7 +917,7 @@ const testPrivate = (settings, options, { absoluteFilePath }, errorMessages) => 
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               8,
               elementTypesNoRuleMessage({
@@ -936,7 +936,7 @@ const testPrivate = (settings, options, { absoluteFilePath }, errorMessages) => 
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               9,
               elementTypesNoRuleMessage({
@@ -955,7 +955,7 @@ const testPrivate = (settings, options, { absoluteFilePath }, errorMessages) => 
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               10,
               elementTypesNoRuleMessage({
@@ -974,7 +974,7 @@ const testPrivate = (settings, options, { absoluteFilePath }, errorMessages) => 
         options,
         errors: [
           {
-            message: elementTypesErrorMessage(
+            message: customErrorMessage(
               errorMessages,
               11,
               elementTypesNoRuleMessage({

--- a/test/rules/two-levels/entry-point.spec.js
+++ b/test/rules/two-levels/entry-point.spec.js
@@ -1,12 +1,10 @@
 const { ENTRY_POINT: RULE } = require("../../../src/constants/rules");
 const { SETTINGS, createRuleTester, pathResolvers } = require("../../support/helpers");
+const { customErrorMessage, entryPointNoRuleMessage } = require("../../support/messages");
 
 const rule = require(`../../../src/rules/${RULE}`);
 
-const errorMessage = (disallowedEntryPoint, type) =>
-  `Entry point '${disallowedEntryPoint}' is not allowed in '${type}'`;
-
-const test = (settings, options, { absoluteFilePath }) => {
+const test = (settings, options, { absoluteFilePath }, errorMessages = {}) => {
   const ruleTester = createRuleTester(settings);
 
   ruleTester.run(RULE, rule, {
@@ -68,7 +66,14 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("index.js", "helpers"),
+            message: customErrorMessage(
+              errorMessages,
+              0,
+              entryPointNoRuleMessage({
+                entryPoint: "index.js",
+                dep: "'helpers' with elementName 'helper-b'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -80,7 +85,14 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("main.js", "helpers"),
+            message: customErrorMessage(
+              errorMessages,
+              1,
+              entryPointNoRuleMessage({
+                entryPoint: "main.js",
+                dep: "'helpers' with elementName 'helper-a'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -92,7 +104,14 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("index.js", "components"),
+            message: customErrorMessage(
+              errorMessages,
+              2,
+              entryPointNoRuleMessage({
+                entryPoint: "index.js",
+                dep: "'components' with category 'atoms' and elementName 'atom-b'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -104,7 +123,14 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("index.js", "components"),
+            message: customErrorMessage(
+              errorMessages,
+              3,
+              entryPointNoRuleMessage({
+                entryPoint: "index.js",
+                dep: "'components' with category 'molecules' and elementName 'molecule-b'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -116,7 +142,14 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("index.js", "components"),
+            message: customErrorMessage(
+              errorMessages,
+              4,
+              entryPointNoRuleMessage({
+                entryPoint: "index.js",
+                dep: "'components' with category 'layouts' and elementName 'layout-a'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -128,7 +161,14 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("index.js", "modules"),
+            message: customErrorMessage(
+              errorMessages,
+              5,
+              entryPointNoRuleMessage({
+                entryPoint: "index.js",
+                dep: "'modules' with domain 'domain-a' and elementName 'module-a'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -140,7 +180,14 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("subfolder-1/subfolder-2/ModuleA.js", "modules"),
+            message: customErrorMessage(
+              errorMessages,
+              6,
+              entryPointNoRuleMessage({
+                entryPoint: "subfolder-1/subfolder-2/ModuleA.js",
+                dep: "'modules' with domain 'domain-a' and elementName 'module-a'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -152,7 +199,14 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("ModuleA.js", "modules"),
+            message: customErrorMessage(
+              errorMessages,
+              7,
+              entryPointNoRuleMessage({
+                entryPoint: "ModuleA.js",
+                dep: "'modules' with domain 'pages' and elementName 'page-a'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -164,7 +218,14 @@ const test = (settings, options, { absoluteFilePath }) => {
         options,
         errors: [
           {
-            message: errorMessage("index.js", "modules"),
+            message: customErrorMessage(
+              errorMessages,
+              8,
+              entryPointNoRuleMessage({
+                entryPoint: "index.js",
+                dep: "'modules' with domain 'pages' and elementName 'page-a'",
+              })
+            ),
             type: "ImportDeclaration",
           },
         ],
@@ -215,7 +276,11 @@ test(
       ],
     },
   ],
-  pathResolvers("two-levels")
+  pathResolvers("two-levels"),
+  {
+    1: "The entry point 'main.js' is not allowed in elements of type 'helpers' with elementName '*-a'. Disallowed in rule 2",
+    7: "The entry point 'ModuleA.js' is not allowed in elements of type 'modules' with domain 'pages'. Disallowed in rule 8",
+  }
 );
 
 test(
@@ -260,5 +325,9 @@ test(
       ],
     },
   ],
-  pathResolvers("two-levels-with-private")
+  pathResolvers("two-levels-with-private"),
+  {
+    1: "The entry point 'main.js' is not allowed in elements of type 'helpers' with elementName '*-a'. Disallowed in rule 2",
+    7: "The entry point 'ModuleA.js' is not allowed in elements of type 'modules' with domain 'pages'. Disallowed in rule 8",
+  }
 );

--- a/test/support/messages.js
+++ b/test/support/messages.js
@@ -2,7 +2,7 @@ function errorMessage(errors, index, defaultMessage) {
   return errors[index] || defaultMessage;
 }
 
-function elementTypesErrorMessage(errors, index, defaultMessage) {
+function customErrorMessage(errors, index, defaultMessage) {
   return errorMessage(errors, index, defaultMessage);
 }
 
@@ -11,6 +11,6 @@ function elementTypesNoRuleMessage({ file, dep }) {
 }
 
 module.exports = {
-  elementTypesErrorMessage,
+  customErrorMessage,
   elementTypesNoRuleMessage,
 };

--- a/test/support/messages.js
+++ b/test/support/messages.js
@@ -10,7 +10,12 @@ function elementTypesNoRuleMessage({ file, dep }) {
   return `No rule allowing this dependency was found. File is of type ${file}. Dependency is of type ${dep}`;
 }
 
+function entryPointNoRuleMessage({ entryPoint, dep }) {
+  return `No rule allows the entry point '${entryPoint}' in dependencies of type ${dep}`;
+}
+
 module.exports = {
   customErrorMessage,
   elementTypesNoRuleMessage,
+  entryPointNoRuleMessage,
 };


### PR DESCRIPTION
### Added
- feat(#169): Support custom messages in `entry-point` rule config

### Fixed
- docs: Fix some typos and links in `element-types` rule docs