### PR TITLE
Replace templates in messages using regexp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 ### Removed
 
+## [unreleased]
+
+### Fixed
+- fix(#295): Replace template values in custom messages using a Regexp, so it replaces all occurrences
+
 ## [3.2.0] - 2023-07-30
 
 ### Changed

--- a/src/helpers/utils.js
+++ b/src/helpers/utils.js
@@ -8,7 +8,8 @@ function isArray(object) {
 
 function replaceObjectValueInTemplate(template, key, value, namespace) {
   const keyToReplace = namespace ? `${namespace}.${key}` : key;
-  return template.replace(`\${${keyToReplace}}`, value);
+  const regexp = new RegExp(`\\$\\{${keyToReplace}\\}`, "g");
+  return template.replace(regexp, value);
 }
 
 function replaceObjectValuesInTemplates(strings, object, namespace) {

--- a/test/rules/one-level/element-types.spec.js
+++ b/test/rules/one-level/element-types.spec.js
@@ -615,7 +615,7 @@ testCapture(
           allow: [["helpers", { elementName: "*-a" }], "c*"],
           disallow: [["c*", { elementName: "*-a" }]],
           message:
-            "Do not import ${dependency.type} named ${dependency.elementName} from ${file.type} named ${file.elementName}",
+            "Do not import ${dependency.type} named ${dependency.elementName} from ${file.type} named ${file.elementName}. Repeat: Do not import ${dependency.type} named ${dependency.elementName} from ${file.type} named ${file.elementName}.",
         },
         {
           from: "modules",
@@ -627,7 +627,7 @@ testCapture(
   {
     0: "Importing helpers with name helper-b is not allowed in components with name component-a",
     1: "Importing helpers with name helper-b is not allowed in components with name component-a",
-    2: "Do not import components named component-a from components named component-b",
+    2: "Do not import components named component-a from components named component-b. Repeat: Do not import components named component-a from components named component-b.",
     3: "Importing helpers with name helper-b is not allowed in modules with name module-a",
   }
 );


### PR DESCRIPTION
- fix: Replace templates in messages using a RegExp, so it replaces all occurrences. closes #295.


