### PR TITLE
Fix null error when using capture matchers in element without captured values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 - fix(#295): Replace template values in custom messages using a Regexp, so it replaces all occurrences
+- fix: Do not throw error when rule contains matchers for captured values but element has not captured values
 
 ### Changed
 - chore(deps): Update dependencies

--- a/src/helpers/rules.js
+++ b/src/helpers/rules.js
@@ -62,6 +62,9 @@ function micromatchPatternReplacingObjectsValues(pattern, object) {
 function isObjectMatch(objectWithMatchers, object, objectsWithValuesToReplace) {
   return Object.keys(objectWithMatchers).reduce((isMatch, key) => {
     if (isMatch) {
+      if (!object) {
+        return false;
+      }
       const micromatchPattern = micromatchPatternReplacingObjectsValues(
         objectWithMatchers[key],
         objectsWithValuesToReplace,

--- a/test/rules/one-level/element-types.spec.js
+++ b/test/rules/one-level/element-types.spec.js
@@ -440,6 +440,10 @@ test(
           from: "components",
           disallow: ["modules"],
         },
+        {
+          from: [["components", { elementName: "component-a" }]],
+          allow: [["modules", { elementName: "module-b" }]],
+        },
       ],
     },
   ],


### PR DESCRIPTION
- fix: Do not throw error when rule contains matchers for captured values but element has not captured values