### PR TITLE
Release v3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 ### Removed
 
-## [unreleased]
+## [3.3.0] - 2023-08-19
 
 ### Added
 - feat(#298): Add `importKind` option to `element-types`, `entry-point` and `external` rules. It allows to define if the rule applies when the dependency is being imported as a value or as a type.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 ### Removed
 
-## [unreleased]
+## [3.4.0] - 2023-08-26
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 ### Removed
 
+## [unreleased]
+
+### Added
+
+- feat(#296): Add `root-path` setting to allow defining the root path of the project. It is useful when executing the eslint command from a different folder than the project root.
+
 ## [3.3.0] - 2023-08-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -228,6 +228,37 @@ Files or dependencies matching these [`micromatch` patterns](https://github.com/
 
 > Note: The `boundaries/include` option has preference over `boundaries/ignore`. If you define `boundaries/include`, use `boundaries/ignore` to ignore subsets of included files.
 
+#### __`boundaries/root-path`__
+
+Use this setting only if you are facing issues with the plugin when executing the lint command from a different path than the project root.
+
+<details>
+<summary>How to define the root path of the project</summary>
+
+By default, the plugin uses the current working directory (`process.cwd()`) as root path of the project. This path is used as the base path when resolving file matchers from rules and `boundaries/elements` settings. This is specially important when using the `basePattern` option or the `full` mode in the `boundaries/elements` setting. This may produce unexpected results [when the lint command is executed from a different path than the project root](https://github.com/javierbrea/eslint-plugin-boundaries/issues/296). To fix this, you can define a different root path using this option.
+
+For example, supposing that the `.eslintrc.js` file is located in the project root, you could define the root path as in:
+
+```js
+{
+  settings: {
+    "boundaries/root-path": path.resolve(__dirname)
+  }
+}
+```
+
+Note that the path should be absolute and resolved before passing it to the plugin. Otherwise, it will be resolved using the current working directory, and the problem will persist. In case you are defining the configuration in a `.eslintrc.(yml|json)` file, and you don't want to hardcode an absolute path, you can use the next environment variable to define the root path when executing the lint command:
+
+```bash
+ESLINT_PLUGIN_BOUNDARIES_ROOT_PATH=../../project-root npm run lint
+```
+
+You can also provide an absolute path in the environment variable, but it may be more useful to use a relative path to the project root. Remember that it will be resolved from the path where the lint command is executed.
+
+</details>
+
+
+
 ### Predefined configurations
 
 This plugin is distributed with two different predefined configurations: "recommended" and "strict".

--- a/jest.config.js
+++ b/jest.config.js
@@ -22,10 +22,6 @@ module.exports = {
       lines: 100,
       statements: 100,
     },
-    // Ignore coverage of debugger
-    "./src/helpers/debug.js": {
-      branches: 83,
-    },
     // Decrease coverage due to cache branches
     "./src/core/elementsInfo.js": {
       branches: 96,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-plugin-boundaries",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-boundaries",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-plugin-boundaries",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-boundaries",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-boundaries",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Eslint plugin checking architecture boundaries between elements",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-boundaries",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Eslint plugin checking architecture boundaries between elements",
   "keywords": [
     "eslint",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=javierbrea
 sonar.projectKey=javierbrea_eslint-plugin-boundaries
-sonar.projectVersion=3.2.0
+sonar.projectVersion=3.3.0
 
 sonar.javascript.file.suffixes=.js
 sonar.sourceEncoding=UTF-8

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=javierbrea
 sonar.projectKey=javierbrea_eslint-plugin-boundaries
-sonar.projectVersion=3.3.0
+sonar.projectVersion=3.4.0
 
 sonar.javascript.file.suffixes=.js
 sonar.sourceEncoding=UTF-8

--- a/src/constants/plugin.js
+++ b/src/constants/plugin.js
@@ -1,5 +1,7 @@
 const PLUGIN_NAME = "boundaries";
+const PLUGIN_ENV_VARS_PREFIX = "ESLINT_PLUGIN_BOUNDARIES";
 
 module.exports = {
   PLUGIN_NAME,
+  PLUGIN_ENV_VARS_PREFIX,
 };

--- a/src/constants/settings.js
+++ b/src/constants/settings.js
@@ -1,4 +1,4 @@
-const { PLUGIN_NAME } = require("./plugin");
+const { PLUGIN_NAME, PLUGIN_ENV_VARS_PREFIX } = require("./plugin");
 
 const {
   ELEMENT_TYPES,
@@ -15,6 +15,11 @@ module.exports = {
   ELEMENTS: `${PLUGIN_NAME}/elements`,
   IGNORE: `${PLUGIN_NAME}/ignore`,
   INCLUDE: `${PLUGIN_NAME}/include`,
+  ROOT_PATH: `${PLUGIN_NAME}/root-path`,
+
+  // env vars
+  DEBUG: `${PLUGIN_ENV_VARS_PREFIX}_DEBUG`,
+  ENV_ROOT_PATH: `${PLUGIN_ENV_VARS_PREFIX}_ROOT_PATH`,
 
   // rules
   RULE_ELEMENT_TYPES: `${PLUGIN_NAME}/${ELEMENT_TYPES}`,

--- a/src/core/elementsInfo.js
+++ b/src/core/elementsInfo.js
@@ -3,7 +3,7 @@ const micromatch = require("micromatch");
 const resolve = require("eslint-module-utils/resolve").default;
 
 const { IGNORE, INCLUDE, VALID_MODES } = require("../constants/settings");
-const { getElements } = require("../helpers/settings");
+const { getElements, getRootPath } = require("../helpers/settings");
 const { debugFileInfo } = require("../helpers/debug");
 const { isArray } = require("../helpers/utils");
 
@@ -184,9 +184,9 @@ function replacePathSlashes(absolutePath) {
   return absolutePath.replace(/\\/g, "/");
 }
 
-function projectPath(absolutePath) {
+function projectPath(absolutePath, rootPath) {
   if (absolutePath) {
-    return replacePathSlashes(absolutePath).replace(`${replacePathSlashes(process.cwd())}/`, "");
+    return replacePathSlashes(absolutePath).replace(`${replacePathSlashes(rootPath)}/`, "");
   }
 }
 
@@ -195,7 +195,7 @@ function externalModulePath(source, baseModuleValue) {
 }
 
 function importInfo(source, context) {
-  const path = projectPath(resolve(source, context));
+  const path = projectPath(resolve(source, context), getRootPath(context.settings));
   const isExternalModule = isExternal(source, path);
   const resultCache = importsCache.load(isExternalModule ? source : path, context.settings);
   let elementCache;
@@ -237,7 +237,7 @@ function importInfo(source, context) {
 }
 
 function fileInfo(context) {
-  const path = projectPath(context.getFilename());
+  const path = projectPath(context.getFilename(), getRootPath(context.settings));
   const resultCache = filesCache.load(path, context.settings);
   let elementCache;
   let result;

--- a/src/helpers/debug.js
+++ b/src/helpers/debug.js
@@ -1,6 +1,7 @@
 const chalk = require("chalk");
 
 const { PLUGIN_NAME } = require("../constants/plugin");
+const { isDebugModeEnabled } = require("./settings");
 
 const warns = [];
 const debuggedFiles = [];
@@ -11,12 +12,6 @@ function trace(message, color) {
 
 function warn(message) {
   trace(message, "yellow");
-}
-
-function debug(message) {
-  if (process.env.ESLINT_PLUGIN_BOUNDARIES_DEBUG) {
-    trace(message, "grey");
-  }
 }
 
 function success(message) {
@@ -32,7 +27,7 @@ function warnOnce(message) {
 
 function debugFileInfo(fileInfo) {
   const fileInfoKey = fileInfo.path || fileInfo.source;
-  if (process.env.ESLINT_PLUGIN_BOUNDARIES_DEBUG && !debuggedFiles.includes(fileInfoKey)) {
+  if (isDebugModeEnabled() && !debuggedFiles.includes(fileInfoKey)) {
     debuggedFiles.push(fileInfoKey);
     if (fileInfo.type) {
       success(`'${fileInfoKey}' is of type '${fileInfo.type}'`);
@@ -44,7 +39,6 @@ function debugFileInfo(fileInfo) {
 }
 
 module.exports = {
-  debug,
   success,
   debugFileInfo,
   warnOnce,

--- a/src/helpers/settings.js
+++ b/src/helpers/settings.js
@@ -1,5 +1,13 @@
-const { TYPES, ELEMENTS, VALID_MODES } = require("../constants/settings");
+const {
+  TYPES,
+  ELEMENTS,
+  VALID_MODES,
+  ROOT_PATH,
+  ENV_ROOT_PATH,
+  DEBUG,
+} = require("../constants/settings");
 const { isString } = require("./utils");
+const { isAbsolute, resolve } = require("path");
 
 function isLegacyType(type) {
   return isString(type);
@@ -34,8 +42,24 @@ function getElementsTypeNames(settings) {
   return getElements(settings).map((element) => element.type);
 }
 
+function getRootPath(settings) {
+  const rootPathUserSetting = process.env[ENV_ROOT_PATH] || settings[ROOT_PATH];
+  if (rootPathUserSetting) {
+    return isAbsolute(rootPathUserSetting)
+      ? rootPathUserSetting
+      : resolve(process.cwd(), rootPathUserSetting);
+  }
+  return process.cwd();
+}
+
+function isDebugModeEnabled() {
+  return process.env[DEBUG];
+}
+
 module.exports = {
   isLegacyType,
   getElements,
   getElementsTypeNames,
+  isDebugModeEnabled,
+  getRootPath,
 };

--- a/test/rules/one-level/element-types.spec.js
+++ b/test/rules/one-level/element-types.spec.js
@@ -1,3 +1,4 @@
+const { resolve } = require("path");
 const { ELEMENT_TYPES: RULE } = require("../../../src/constants/rules");
 const { SETTINGS, createRuleTester, pathResolvers } = require("../../support/helpers");
 const { customErrorMessage, elementTypesNoRuleMessage } = require("../../support/messages");
@@ -463,6 +464,50 @@ test(
 
 test(
   SETTINGS.oneLevel,
+  [
+    {
+      default: "disallow",
+      rules: [
+        {
+          from: "components",
+          allow: ["helpers", "components"],
+        },
+        {
+          from: "modules",
+          allow: ["helpers", "components", "modules"],
+        },
+      ],
+    },
+  ],
+  {},
+);
+
+// root-path absolute setting
+
+test(
+  { ...SETTINGS.oneLevel, "boundaries/root-path": resolve(__dirname, "..", "..", "..") },
+  [
+    {
+      default: "disallow",
+      rules: [
+        {
+          from: "components",
+          allow: ["helpers", "components"],
+        },
+        {
+          from: "modules",
+          allow: ["helpers", "components", "modules"],
+        },
+      ],
+    },
+  ],
+  {},
+);
+
+// root-path relative setting
+
+test(
+  { ...SETTINGS.oneLevel, "boundaries/root-path": "." },
   [
     {
       default: "disallow",


### PR DESCRIPTION
### Added

- feat: Add `root-path` setting to allow defining the root path of the project. It is useful when executing the eslint command from a different folder than the project root. closes #296 