### PR TITLE
fix: Avoid error when rule element matchers define a capture key but …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 ### BREAKING CHANGES
 
+## [4.0.1] - 2023-12-01
+
+### Fixed
+- fix: Avoid error when rule element matchers define a capture key but some element does not have that capture key
+
 ## [4.0.0] - 2023-12-01
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-plugin-boundaries",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-boundaries",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-boundaries",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Eslint plugin checking architecture boundaries between elements",
   "keywords": [
     "eslint",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=javierbrea
 sonar.projectKey=javierbrea_eslint-plugin-boundaries
-sonar.projectVersion=4.0.0
+sonar.projectVersion=4.0.1
 
 sonar.javascript.file.suffixes=.js
 sonar.sourceEncoding=UTF-8

--- a/src/helpers/rules.js
+++ b/src/helpers/rules.js
@@ -45,7 +45,7 @@ function micromatchPatternReplacingObjectsValues(pattern, object) {
 function isObjectMatch(objectWithMatchers, object, objectsWithValuesToReplace) {
   return Object.keys(objectWithMatchers).reduce((isMatch, key) => {
     if (isMatch) {
-      if (!object) {
+      if (!object || !object[key]) {
         return false;
       }
       const micromatchPattern = micromatchPatternReplacingObjectsValues(

--- a/test/rules/one-level/element-types.spec.js
+++ b/test/rules/one-level/element-types.spec.js
@@ -749,6 +749,10 @@ testCapture(
           from: "modules",
           allow: [["h*", { elementName: "*-a" }], "c*", "m*"],
         },
+        {
+          from: "modules",
+          disallow: [["h*", { foo: "*-a" }], "c*", "m*"],
+        },
       ],
     },
   ],


### PR DESCRIPTION
### Fixed
- fix: Avoid error when rule element matchers define a capture key but some element does not have that capture key