### PR TITLE
Remove `is-core-module` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "chalk": "4.1.2",
         "eslint-import-resolver-node": "0.3.9",
         "eslint-module-utils": "2.8.1",
-        "is-core-module": "2.13.1",
         "micromatch": "4.0.5"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "chalk": "4.1.2",
     "eslint-import-resolver-node": "0.3.9",
     "eslint-module-utils": "2.8.1",
-    "is-core-module": "2.13.1",
     "micromatch": "4.0.5"
   },
   "devDependencies": {

--- a/src/core/elementsInfo.js
+++ b/src/core/elementsInfo.js
@@ -9,7 +9,7 @@ const { isArray } = require("../helpers/utils");
 
 const { filesCache, importsCache, elementsCache } = require("./cache");
 
-function isBuiltin(moduleName) {
+function isCoreModule(moduleName) {
   const moduleNameWithoutPrefix = moduleName.startsWith("node:")
     ? moduleName.slice(5)
     : moduleName;
@@ -46,7 +46,7 @@ function isIgnored(path, settings) {
 function isBuiltIn(name, path) {
   if (path || !name) return false;
   const base = baseModule(name);
-  return isBuiltin(base);
+  return isCoreModule(base);
 }
 
 const scopedRegExp = /^@[^/]*\/?[^/]+/;

--- a/src/core/elementsInfo.js
+++ b/src/core/elementsInfo.js
@@ -1,4 +1,4 @@
-const isCoreModule = require("is-core-module");
+const mod = require("module");
 const micromatch = require("micromatch");
 const resolve = require("eslint-module-utils/resolve").default;
 
@@ -8,6 +8,14 @@ const { debugFileInfo } = require("../helpers/debug");
 const { isArray } = require("../helpers/utils");
 
 const { filesCache, importsCache, elementsCache } = require("./cache");
+
+function isBuiltin(moduleName) {
+  const moduleNameWithoutPrefix = moduleName.startsWith("node:")
+    ? moduleName.slice(5)
+    : moduleName;
+
+  return mod.builtinModules.includes(moduleNameWithoutPrefix);
+}
 
 function baseModule(name) {
   if (isScoped(name)) {
@@ -38,7 +46,7 @@ function isIgnored(path, settings) {
 function isBuiltIn(name, path) {
   if (path || !name) return false;
   const base = baseModule(name);
-  return isCoreModule(base);
+  return isBuiltin(base);
 }
 
 const scopedRegExp = /^@[^/]*\/?[^/]+/;

--- a/test/rules/one-level/element-types.spec.js
+++ b/test/rules/one-level/element-types.spec.js
@@ -166,6 +166,18 @@ const test = (settings, options, errorMessages) => {
           },
         ],
       },
+      // Can import fs module
+      {
+        filename: absoluteFilePath("modules/module-a/ModuleA.js"),
+        code: "import fs from 'fs'",
+        options,
+      },
+      // Can import node:fs module
+      {
+        filename: absoluteFilePath("modules/module-a/ModuleA.js"),
+        code: "import fs from 'node:fs'",
+        options,
+      },
     ],
     invalid: [
       // Helpers can't import another if everything is disallowed


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

Node.js from v6.13.0, v8.10.0, v9.3.0 includes `module.builtinModules` which we can use to natively check if some module belongs to Node.js core or not.

This drops not one, but _three_ dependencies, removing 70 KB of bloat: https://npmgraph.js.org/?q=is-core-module

**Closing issues**

Closes #334 

