### PR TITLE
Clarify include / exclude precedence

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Files or dependencies matching these [`micromatch` patterns](https://github.com/
 }
 ```
 
-> Note: The `boundaries/include` option has preference over `boundaries/ignore`. If you define `boundaries/include`, use `boundaries/ignore` to ignore subsets of included files.
+> Note: The `boundaries/ignore` option has precidence over `boundaries/include`. If you define `boundaries/include`, use `boundaries/ignore` to ignore subsets of included files.
 
 #### __`boundaries/root-path`__
 

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Files or dependencies matching these [`micromatch` patterns](https://github.com/
 }
 ```
 
-> Note: The `boundaries/ignore` option has precidence over `boundaries/include`. If you define `boundaries/include`, use `boundaries/ignore` to ignore subsets of included files.
+> Note: The `boundaries/ignore` option has precedence over `boundaries/include`. If you define `boundaries/include`, use `boundaries/ignore` to ignore subsets of included files.
 
 #### __`boundaries/root-path`__
 


### PR DESCRIPTION
While reading the docs, I found a sentence that was ambiguous and potentially misleading.

> Note: The boundaries/include option has preference over boundaries/ignore. If you define boundaries/include, use boundaries/ignore to ignore subsets of included files.

"boundaries/include has preference" could mean two things:

1. boundaries/include is applied first, and boundaries/ignore is applied after. boundaries/exclude has precedence.
2. boundaries/include is preferred. boundaries/include has precedence.

I edited the docs to use the word "precedence",  which removes the ambiguousness.