### PR TITLE
Release v6.0.1

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 ### Breaking Changes
 
+## [6.0.1] - 2026-03-20
+
+### Fixed
+
+- fix([#438](https://github.com/javierbrea/eslint-plugin-boundaries/issues/438)): Fix `createConfig` helper types when used in Eslint v10.x. Returned type is now compatible both with eslint v9 and eslint v10.
+
 ## [6.0.0] - 2026-03-15
 
 ### Added

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boundaries/eslint-plugin",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "Eslint plugin checking architecture boundaries between elements",
   "keywords": [
     "eslint",

--- a/packages/eslint-plugin/sonar-project.properties
+++ b/packages/eslint-plugin/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=javierbrea
 sonar.projectKey=javierbrea_eslint-plugin-boundaries
-sonar.projectVersion=6.0.0
+sonar.projectVersion=6.0.1
 
 sonar.javascript.file.suffixes=.js
 sonar.sourceEncoding=UTF-8

--- a/packages/eslint-plugin/src/Config/Config.ts
+++ b/packages/eslint-plugin/src/Config/Config.ts
@@ -2,7 +2,7 @@ import type { Linter } from "eslint";
 
 import plugin from "../index";
 import { isRuleShortName, isSettingsKey } from "../Settings";
-import type { PluginBoundaries, Config, Rules } from "../Shared";
+import type { Config, Rules } from "../Shared";
 import { PLUGIN_NAME } from "../Shared";
 
 import recommendedConfig from "./Recommended";
@@ -12,11 +12,11 @@ export * from "../Public";
 
 /**
  * The full ESLint config object returned by createConfig, including the plugins field with the boundaries plugin registered.
+ * Configuration object returned by createConfig.
+ * We use a public alias to keep the exported type nameable and portable.
+ * This helps prevent TS2742 errors caused by inferred types leaking internal ESLint type paths.
  */
-type PluginFullConfig<PluginName extends string = typeof PLUGIN_NAME> = {
-  plugins: Record<PluginName, PluginBoundaries>;
-  files: Linter.Config["files"];
-} & Omit<Config<PluginName>, "plugins">;
+export type ConfigObject = Linter.Config;
 
 /**
  * Rewrites rule keys to the effective plugin namespace used by `createConfig`.
@@ -75,7 +75,7 @@ function renamePluginRules<PluginName extends string = typeof PLUGIN_NAME>(
  *
  * @param config - ESLint config object without the plugins field.
  * @param name - The name of the plugin to register. Defaults to "boundaries".
- * @returns {Linter.Config} The ESLint config object with the boundaries plugin registered and the provided config merged in.
+ * @returns {ConfigObject} The ESLint config object with the boundaries plugin registered and the provided config merged in.
  * @throws {Error} If settings or rules are not from eslint-plugin-boundaries.
  *
  * @example
@@ -100,10 +100,12 @@ function renamePluginRules<PluginName extends string = typeof PLUGIN_NAME>(
 export function createConfig<PluginName extends string = typeof PLUGIN_NAME>(
   config: Omit<Config<PluginName> | Config, "plugins">,
   name: PluginName = PLUGIN_NAME as PluginName
-): PluginFullConfig<PluginName> {
-  const pluginsRegistration = {
+): ConfigObject {
+  // Annotate plugins as Record<string, object> to prevent TypeScript from inferring
+  // the internal plugin type, which would expose ESLint internal generic types
+  const pluginsRegistration: Record<string, object> = {
     [name]: plugin,
-  } as Record<PluginName, PluginBoundaries>;
+  };
 
   if (Object.hasOwn(config, "plugins")) {
     throw new Error(

--- a/test/eslint-plugin-e2e/CHANGELOG.md
+++ b/test/eslint-plugin-e2e/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 ### BREAKING CHANGES
 
+## [1.1.0] - 2026-03-20
+
+### Changed
+
+- feat: Adapt typing E2E tests to check that the createConfig helper returns a `Linter.Config` compatible shape.
 
 ## [1.0.0] - 2026-03-14
 

--- a/test/eslint-plugin-e2e/package.json
+++ b/test/eslint-plugin-e2e/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boundaries/eslint-plugin-e2e",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/test/eslint-plugin-e2e/test/configs-ts/recommended.config.ts
+++ b/test/eslint-plugin-e2e/test/configs-ts/recommended.config.ts
@@ -1,10 +1,11 @@
 import boundaries from "@boundaries/eslint-plugin";
 import type { Config } from "@boundaries/eslint-plugin";
 import recommendedBoundariesConfig from "@boundaries/eslint-plugin/recommended";
+import type { Linter } from "eslint";
 
 import baseBasicFixtureConfig from "./baseBasicFixture.config.js";
 
-const config: Config = {
+const boundariesConfig: Config = {
   ...baseBasicFixtureConfig,
   plugins: {
     boundaries,
@@ -15,4 +16,6 @@ const config: Config = {
   },
 };
 
-export default [config];
+const config: Linter.Config[] = [boundariesConfig];
+
+export default config;

--- a/test/eslint-plugin-e2e/test/configs/baseBasicFixture.config.js
+++ b/test/eslint-plugin-e2e/test/configs/baseBasicFixture.config.js
@@ -1,3 +1,4 @@
+/** @type {import('eslint').Linter.Config} */
 export default {
   files: ["**/*.js", "**/*.ts"],
   settings: {
@@ -15,6 +16,7 @@ export default {
     ],
     "boundaries/ignore": ["**/ignored/**/*.js"],
   },
+  /** @type {import('@boundaries/eslint-plugin').Rules} */
   rules: {
     "boundaries/element-types": [
       "error",

--- a/test/eslint-plugin-e2e/test/configs/createConfig.config.js
+++ b/test/eslint-plugin-e2e/test/configs/createConfig.config.js
@@ -6,6 +6,7 @@ import recommendedBoundariesConfig from "@boundaries/eslint-plugin/recommended";
 
 import baseBasicFixtureConfig from "./baseBasicFixture.config.js";
 
+/** @type {import('eslint').Linter.Config[]} */
 export default [
   createConfig({
     rules: /** @type {import('@boundaries/eslint-plugin').Rules} */ ({

--- a/test/eslint-plugin-e2e/test/configs/monorepo.config.js
+++ b/test/eslint-plugin-e2e/test/configs/monorepo.config.js
@@ -24,6 +24,7 @@ export default [
       ],
       "boundaries/dependency-nodes": ["import"],
     },
+    /** @type {import('@boundaries/eslint-plugin').Rules} */
     rules: {
       ...strictBoundariesConfig.rules,
       "boundaries/element-types": [

--- a/test/eslint-plugin-e2e/test/configs/recommended.config.js
+++ b/test/eslint-plugin-e2e/test/configs/recommended.config.js
@@ -5,15 +5,15 @@ import recommendedBoundariesConfig from "@boundaries/eslint-plugin/recommended";
 
 import baseBasicFixtureConfig from "./baseBasicFixture.config.js";
 
-export default [
-  {
-    ...baseBasicFixtureConfig,
-    plugins: {
-      boundaries,
-    },
-    rules: {
-      ...recommendedBoundariesConfig.rules,
-      ...baseBasicFixtureConfig.rules,
-    },
+/** @type {import('@boundaries/eslint-plugin').Config} */
+const boundariesConfig = {
+  ...baseBasicFixtureConfig,
+  plugins: { boundaries },
+  rules: {
+    ...recommendedBoundariesConfig.rules,
+    ...baseBasicFixtureConfig.rules,
   },
-];
+};
+
+/** @type {import('eslint').Linter.Config[]} */
+export default [boundariesConfig];

--- a/test/eslint-plugin-e2e/test/configs/strict.config.js
+++ b/test/eslint-plugin-e2e/test/configs/strict.config.js
@@ -5,15 +5,15 @@ import strictBoundariesConfig from "@boundaries/eslint-plugin/strict";
 
 import baseBasicFixtureConfig from "./baseBasicFixture.config.js";
 
-export default [
-  {
-    ...baseBasicFixtureConfig,
-    plugins: {
-      boundaries,
-    },
-    rules: {
-      ...strictBoundariesConfig.rules,
-      ...baseBasicFixtureConfig.rules,
-    },
+/** @type {import('@boundaries/eslint-plugin').Config} */
+const boundariesConfig = {
+  ...baseBasicFixtureConfig,
+  plugins: { boundaries },
+  rules: {
+    ...strictBoundariesConfig.rules,
+    ...baseBasicFixtureConfig.rules,
   },
-];
+};
+
+/** @type {import('eslint').Linter.Config[]} */
+export default [boundariesConfig];


### PR DESCRIPTION
# Make createConfig helper typings compatible with eslint v10

## Description

- fix(#438): Fix `createConfig` helper types when used in Eslint v10.x. Returned type is now compatible both with eslint v9 and eslint v10.

## Agreement

Please check the following boxes after you have read and understood each item.

* [x] I have read the [CONTRIBUTING](https://github.com/javierbrea/eslint-plugin-boundaries/blob/master/.github/CONTRIBUTING.md) document
* [x] I have read the [CODE_OF_CONDUCT](https://github.com/javierbrea/eslint-plugin-boundaries/blob/master/.github/CODE_OF_CONDUCT.md) document
* [x] I have read the [CONTRIBUTOR LICENSE AGREEMENT](https://github.com/javierbrea/eslint-plugin-boundaries/blob/master/.github/CLA.md) document, and I agree to the terms and declare that all my contributions are compliant with it.

closes #438 
