### PR TITLE
fix: update handlebars to 4.7.9 to resolve critical vulnerability

### DIFF
--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "eslint-import-resolver-node": "0.3.9",
     "eslint-module-utils": "2.12.1",
-    "handlebars": "4.7.8",
+    "handlebars": "4.7.9",
     "is-core-module": "2.16.1",
     "micromatch": "4.0.8"
   },

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -69,7 +69,7 @@
     "chalk": "4.1.2",
     "eslint-import-resolver-node": "0.3.9",
     "eslint-module-utils": "2.12.1",
-    "handlebars": "4.7.8",
+    "handlebars": "4.7.9",
     "micromatch": "4.0.8"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: 2.12.1
         version: 2.12.1(@typescript-eslint/parser@8.57.0(eslint@9.37.0(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.37.0(jiti@1.21.7))
       handlebars:
-        specifier: 4.7.8
-        version: 4.7.8
+        specifier: 4.7.9
+        version: 4.7.9
       is-core-module:
         specifier: 2.16.1
         version: 2.16.1
@@ -121,8 +121,8 @@ importers:
         specifier: 2.12.1
         version: 2.12.1(@typescript-eslint/parser@8.57.0(eslint@9.37.0(jiti@1.21.7))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.37.0(jiti@1.21.7))
       handlebars:
-        specifier: 4.7.8
-        version: 4.7.8
+        specifier: 4.7.9
+        version: 4.7.9
       micromatch:
         specifier: 4.0.8
         version: 4.0.8
@@ -5253,8 +5253,8 @@ packages:
   handle-thing@2.0.1:
     resolution: {integrity: sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==}
 
-  handlebars@4.7.8:
-    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
     engines: {node: '>=0.4.7'}
     hasBin: true
 
@@ -15257,7 +15257,7 @@ snapshots:
 
   handle-thing@2.0.1: {}
 
-  handlebars@4.7.8:
+  handlebars@4.7.9:
     dependencies:
       minimist: 1.2.8
       neo-async: 2.6.2


### PR DESCRIPTION
## Summary

- Updated `handlebars` from `4.7.8` to `4.7.9` in both `@boundaries/elements` and `eslint-plugin-boundaries`
- Resolves critical vulnerability [GHSA-2w6w-674q-4c4q](https://github.com/advisories/GHSA-2w6w-674q-4c4q) and multiple High/Medium CVEs in handlebars 4.7.8

## Changes

- `packages/elements/package.json`: `handlebars` `4.7.8` → `4.7.9`
- `packages/eslint-plugin/package.json`: `handlebars` `4.7.8` → `4.7.9`
- `pnpm-lock.yaml`: updated accordingly