### PR TITLE
docs(#448): Fix paths in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ Define your dependency rules:
 Now ESLint will catch violations:
 
 ```javascript
-// In src/models/model.js
-import View from "../views/view"; // ❌ Error: Architectural boundary violated
+// In src/models/model/index.js
+import View from "../../views/view"; // ❌ Error: Architectural boundary violated
 ```
 
 ## Contributing

--- a/packages/website/docs/overview.md
+++ b/packages/website/docs/overview.md
@@ -61,17 +61,17 @@ const elementDescriptors = [
 Given this configuration, the plugin will analyze your project in runtime and classify dependencies, providing lots of useful metadata about the files and their relationships. For example:
 
 ```javascript
-// When analyzing a dependency in src/controllers/controller-a.js
+// When analyzing a dependency in src/controllers/controller-a/index.js
 {
   from: {
-    path: "src/controllers/controller-a.js",
+    path: "src/controllers/controller-a/index.js",
     type: "controller",
     category: null,
     captured: { elementName: "controller-a" },
     origin: "local",
   },
   to: {
-    path: "src/views/view-a.js",
+    path: "src/views/view-a/index.js",
     type: "view",
     category: null,
     captured: { elementName: "view-a" },
@@ -79,7 +79,7 @@ Given this configuration, the plugin will analyze your project in runtime and cl
   },
   dependency: {
     kind: "value",
-    source: "@views/view-a.js",
+    source: "@views/view-a",
     specifiers: ["ViewA"],
   }
 }
@@ -150,9 +150,9 @@ const dependencyRules = [
 When a file violates a dependencies rule, ESLint will report an error:
 
 ```javascript
-// In src/models/model-a.js
+// In src/models/model-a/index.js
 
-import View  from '../views/view-a';
+import View  from '../../views/view-a';
 
 /* ❌ Error: Importing elements of type 'views'
 is not allowed in elements of type 'models'.

--- a/packages/website/versioned_docs/version-5.3.0/overview.md
+++ b/packages/website/versioned_docs/version-5.3.0/overview.md
@@ -78,9 +78,9 @@ const dependencyRules = [
 When a file violates a dependencies rule, ESLint will report an error:
 
 ```javascript
-// In src/models/model-a.js
+// In src/models/model-a/index.js
 
-import View  from '../views/view-a'; /* ❌ Error: Importing elements of type
+import View  from '../../views/view-a'; /* ❌ Error: Importing elements of type
 'views' is not allowed in elements of type 'models'. Disallowed in rule 3 */
 ```
 

--- a/packages/website/versioned_docs/version-5.4.0/overview.md
+++ b/packages/website/versioned_docs/version-5.4.0/overview.md
@@ -78,9 +78,9 @@ const dependencyRules = [
 When a file violates a dependencies rule, ESLint will report an error:
 
 ```javascript
-// In src/models/model-a.js
+// In src/models/model-a/index.js
 
-import View  from '../views/view-a'; /* ❌ Error: Importing elements of type
+import View  from '../../views/view-a'; /* ❌ Error: Importing elements of type
 'views' is not allowed in elements of type 'models'. Disallowed in rule 3 */
 ```
 

--- a/packages/website/versioned_docs/version-6.0.0/overview.md
+++ b/packages/website/versioned_docs/version-6.0.0/overview.md
@@ -61,17 +61,17 @@ const elementDescriptors = [
 Given this configuration, the plugin will analyze your project in runtime and classify dependencies, providing lots of useful metadata about the files and their relationships. For example:
 
 ```javascript
-// When analyzing a dependency in src/controllers/controller-a.js
+// When analyzing a dependency in src/controllers/controller-a/index.js
 {
   from: {
-    path: "src/controllers/controller-a.js",
+    path: "src/controllers/controller-a/index.js",
     type: "controller",
     category: null,
     captured: { elementName: "controller-a" },
     origin: "local",
   },
   to: {
-    path: "src/views/view-a.js",
+    path: "src/views/view-a/index.js",
     type: "view",
     category: null,
     captured: { elementName: "view-a" },
@@ -79,7 +79,7 @@ Given this configuration, the plugin will analyze your project in runtime and cl
   },
   dependency: {
     kind: "value",
-    source: "@views/view-a.js",
+    source: "@views/view-a",
     specifiers: ["ViewA"],
   }
 }
@@ -150,9 +150,9 @@ const dependencyRules = [
 When a file violates a dependencies rule, ESLint will report an error:
 
 ```javascript
-// In src/models/model-a.js
+// In src/models/model-a/index.js
 
-import View  from '../views/view-a';
+import View  from '../../views/view-a';
 
 /* ❌ Error: Importing elements of type 'views'
 is not allowed in elements of type 'models'.


### PR DESCRIPTION
# Update example file paths to match default folder mode patterns

## Description

* Updated example file paths in documentation to use folder-based structure (e.g. controllers/controller-a/index.js instead of controllers/controller-a.js), which correctly matches the default mode: "folder" element patterns like controllers/*

## Agreement

Please check the following boxes after you have read and understood each item.

* [x] I have read the [CONTRIBUTING](https://github.com/javierbrea/eslint-plugin-boundaries/blob/master/.github/CONTRIBUTING.md) document
* [x] I have read the [CODE_OF_CONDUCT](https://github.com/javierbrea/eslint-plugin-boundaries/blob/master/.github/CODE_OF_CONDUCT.md) document
* [x] I have read the [CONTRIBUTOR LICENSE AGREEMENT](https://github.com/javierbrea/eslint-plugin-boundaries/blob/master/.github/CLA.md) document, and I agree to the terms and declare that all my contributions are compliant with it.

closes #448 
