### PR TITLE
fix: Fix files capture

### DIFF
--- a/packages/elements/CHANGELOG.md
+++ b/packages/elements/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [3.0.1] - 2026-07-06
+
+### Fixed
+
+- fix(#457): File descriptors now honor a plain `capture` array without requiring `basePattern`. Previously, `capture` on a `boundaries/files` descriptor without `basePattern` always resulted in `file.captured` being `null`.
+
 ## [3.0.0] - 2026-07-05
 
 ### Breaking Changes

--- a/packages/elements/package.json
+++ b/packages/elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boundaries/elements",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Element descriptors and matchers for @boundaries tools",
   "keywords": [
     "boundaries",

--- a/packages/elements/sonar-project.properties
+++ b/packages/elements/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=javierbrea
 sonar.projectKey=javierbrea_eslint-plugin-boundaries_elements
-sonar.projectVersion=3.0.0
+sonar.projectVersion=3.0.1
 
 sonar.javascript.file.suffixes=.js
 sonar.sourceEncoding=UTF-8

--- a/packages/elements/src/Descriptor/File/FileDescriptor.spec.ts
+++ b/packages/elements/src/Descriptor/File/FileDescriptor.spec.ts
@@ -495,7 +495,7 @@ describe("FilesDescriptor", () => {
         expect(result.captured).toBeNull();
       });
 
-      it("should return null captured when descriptor has capture but no basePattern", () => {
+      it("should capture values when descriptor has capture but no basePattern", () => {
         const micromatch = createMicromatchMock({
           capture: jest.fn().mockReturnValue(["modules"]),
         });
@@ -514,7 +514,39 @@ describe("FilesDescriptor", () => {
 
         const result = descriptor.describeFile("src/modules/auth/service.ts");
 
-        expect(result.captured).toBeNull();
+        expect(result.captured).toEqual({ layer: "modules" });
+      });
+
+      it("should merge captured values from multiple matching descriptors with plain capture and no basePattern", () => {
+        const captureMock = jest
+          .fn()
+          .mockReturnValueOnce(["modules"])
+          .mockReturnValueOnce(["service"]);
+        const micromatch = createMicromatchMock({
+          capture: captureMock,
+        });
+        const config = createConfig({ rootPath: undefined });
+        const descriptors: FileDescriptors = [
+          createFileDescriptor({
+            pattern: "src/(*)/**/*.ts",
+            category: "source",
+            capture: ["layer"],
+          }),
+          createFileDescriptor({
+            pattern: "src/**/(*).ts",
+            category: "typescript",
+            capture: ["fileName"],
+          }),
+        ];
+        const descriptor = new FilesDescriptor(descriptors, config, micromatch);
+
+        const result = descriptor.describeFile("src/modules/auth/service.ts");
+
+        expect(result.categories).toEqual(["source", "typescript"]);
+        expect(result.captured).toEqual({
+          layer: "modules",
+          fileName: "service",
+        });
       });
 
       it("should skip capture indices without a name in the config", () => {

--- a/packages/elements/src/Descriptor/File/FileDescriptor.ts
+++ b/packages/elements/src/Descriptor/File/FileDescriptor.ts
@@ -168,9 +168,11 @@ export class FilesDescriptor {
   }
 
   /**
-   * Returns the capture array for a file descriptor, combining baseCapture and capture if basePattern is used, for backward compatibility with legacy mode "file".
+   * Returns the capture array for a file descriptor. When basePattern is used, combines baseCapture
+   * and capture for backward compatibility with legacy mode "file". Otherwise, returns the plain
+   * capture array as-is, matching it directly against the pattern's own capture groups.
    * @param fileDescriptor The file descriptor to get the capture array for.
-   * @returns The combined capture array if basePattern is used, otherwise undefined.
+   * @returns The capture array, or undefined if no capture is configured.
    */
   private _getCaptureArray(
     fileDescriptor: FileDescriptor
@@ -194,6 +196,7 @@ export class FilesDescriptor {
         ];
       }
     }
+    return fileDescriptor.capture;
   }
 
   /**

--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [7.0.1] - 2026-07-06
+
+### Fixed
+
+- fix(#457): Upgrade `@boundaries/elements` to v3.0.1. File descriptors now honor a plain `capture` array without requiring `basePattern`. Previously, `capture` on a `boundaries/files` descriptor without `basePattern` always resulted in `file.captured` being `null`.
+
 ## [7.0.0] - 2026-07-05
 
 ### Highlights

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boundaries/eslint-plugin",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Eslint plugin checking architecture boundaries between elements",
   "keywords": [
     "eslint",

--- a/packages/eslint-plugin/sonar-project.properties
+++ b/packages/eslint-plugin/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=javierbrea
 sonar.projectKey=javierbrea_eslint-plugin-boundaries
-sonar.projectVersion=7.0.0
+sonar.projectVersion=7.0.1
 
 sonar.javascript.file.suffixes=.js
 sonar.sourceEncoding=UTF-8

--- a/packages/eslint-plugin/test/rules/one-level/element-types-file-selectors-v7.spec.ts
+++ b/packages/eslint-plugin/test/rules/one-level/element-types-file-selectors-v7.spec.ts
@@ -104,6 +104,36 @@ const captureSettings: RuleTesterSettings = {
   ],
 } as RuleTesterSettings;
 
+// Settings using file descriptors WITH plain capture and no basePattern.
+// This is the plain-capture equivalent of `captureSettings` above: the same captured values are
+// produced now that `capture` without `basePattern` is honored (regression coverage for
+// https://github.com/javierbrea/eslint-plugin-boundaries/issues/457).
+const captureSettingsNoBasePattern: RuleTesterSettings = {
+  ...SETTINGS.oneLevel,
+  "boundaries/elements": [
+    { type: "helpers", pattern: "helpers/*", capture: ["elementName"] },
+    { type: "components", pattern: ["components/*"], capture: ["elementName"] },
+    { type: "modules", pattern: "modules/*", capture: ["elementName"] },
+  ],
+  "boundaries/files": [
+    {
+      category: "helpers",
+      pattern: "**/helpers/*/*.js",
+      capture: ["restOfPath", "elementName", "fileName"],
+    },
+    {
+      category: "components",
+      pattern: "**/components/*/*.js",
+      capture: ["restOfPath", "elementName", "fileName"],
+    },
+    {
+      category: "modules",
+      pattern: "**/modules/*/*.js",
+      capture: ["restOfPath", "elementName", "fileName"],
+    },
+  ],
+} as RuleTesterSettings;
+
 const runTest = (
   settings: RuleTesterSettings,
   options: unknown[],
@@ -644,6 +674,55 @@ runTest(
 
 testFileCaptured(
   captureSettings,
+  [
+    {
+      default: "disallow",
+      policies: [
+        {
+          from: { file: { categories: "components" } },
+          allow: {
+            to: [
+              {
+                file: {
+                  categories: "helpers",
+                  captured: { elementName: "helper-a" },
+                },
+              },
+              {
+                file: {
+                  categories: "components",
+                  captured: { elementName: "!component-a" },
+                },
+              },
+            ],
+          },
+        },
+        {
+          from: { file: { categories: "modules" } },
+          allow: {
+            to: [
+              {
+                file: {
+                  categories: "helpers",
+                  captured: { elementName: "helper-a" },
+                },
+              },
+              { file: { categories: "components" } },
+              { file: { categories: "modules" } },
+            ],
+          },
+        },
+      ],
+    },
+  ],
+  {}
+);
+
+// Same scenario, using plain `capture` without `basePattern` (regression test for
+// https://github.com/javierbrea/eslint-plugin-boundaries/issues/457).
+
+testFileCaptured(
+  captureSettingsNoBasePattern,
   [
     {
       default: "disallow",

--- a/packages/website/docs/classification/elements.md
+++ b/packages/website/docs/classification/elements.md
@@ -142,6 +142,10 @@ Captures named values from path fragments so you can reference them later in [el
 
 Each captured fragment is stored under the key from the `capture` array at the same index.
 
+:::note
+`capture` maps positionally to each wildcard (`*` or `**`) in `pattern`, in order, left to right. Count the wildcards in your pattern and provide that many names; naming fewer just leaves the trailing wildcards uncaptured (see "Combine with `partialMatch` for targeted captures" below), but naming them in the wrong order (or forgetting one in the middle, such as a `**`) assigns each name to the wrong path fragment.
+:::
+
 ```js
 { type: "component", pattern: "components/*/*", capture: ["family", "elementName"] }
 ```

--- a/packages/website/docs/classification/files.md
+++ b/packages/website/docs/classification/files.md
@@ -81,8 +81,18 @@ Captures named values from path fragments so you can reference them later in [fi
 
 Each captured fragment is stored under the key from the `capture` array at the same index, and appears at runtime as `file.captured`.
 
+:::note
+`capture` maps positionally to each wildcard (`*` or `**`) in `pattern`, in order, left to right — including any `**` used to match nested paths. Count the wildcards in your pattern and provide that many names; naming fewer just leaves the trailing wildcards uncaptured, but naming them in the wrong order (or forgetting one in the middle, such as a `**`) assigns each name to the wrong path fragment.
+:::
+
 ```js
-{ pattern: "**/*.stories.*", category: "story", capture: ["fileName"] }
+{ pattern: "**/*.stories.*", category: "story", capture: ["restOfPath", "fileName", "extension"] }
+```
+
+For a path `components/Button/Button.stories.tsx`, this captures:
+
+```js
+{ restOfPath: "components/Button", fileName: "Button", extension: "tsx" }
 ```
 
 When several matching descriptors capture values, those values are **merged** into a single `file.captured` object.

--- a/packages/website/versioned_docs/version-7.0.0/classification/elements.md
+++ b/packages/website/versioned_docs/version-7.0.0/classification/elements.md
@@ -142,6 +142,10 @@ Captures named values from path fragments so you can reference them later in [el
 
 Each captured fragment is stored under the key from the `capture` array at the same index.
 
+:::note
+`capture` maps positionally to each wildcard (`*` or `**`) in `pattern`, in order, left to right. Count the wildcards in your pattern and provide that many names; naming fewer just leaves the trailing wildcards uncaptured (see "Combine with `partialMatch` for targeted captures" below), but naming them in the wrong order (or forgetting one in the middle, such as a `**`) assigns each name to the wrong path fragment.
+:::
+
 ```js
 { type: "component", pattern: "components/*/*", capture: ["family", "elementName"] }
 ```

--- a/packages/website/versioned_docs/version-7.0.0/classification/files.md
+++ b/packages/website/versioned_docs/version-7.0.0/classification/files.md
@@ -81,8 +81,18 @@ Captures named values from path fragments so you can reference them later in [fi
 
 Each captured fragment is stored under the key from the `capture` array at the same index, and appears at runtime as `file.captured`.
 
+:::note
+`capture` maps positionally to each wildcard (`*` or `**`) in `pattern`, in order, left to right — including any `**` used to match nested paths. Count the wildcards in your pattern and provide that many names; naming fewer just leaves the trailing wildcards uncaptured, but naming them in the wrong order (or forgetting one in the middle, such as a `**`) assigns each name to the wrong path fragment.
+:::
+
 ```js
-{ pattern: "**/*.stories.*", category: "story", capture: ["fileName"] }
+{ pattern: "**/*.stories.*", category: "story", capture: ["restOfPath", "fileName", "extension"] }
+```
+
+For a path `components/Button/Button.stories.tsx`, this captures:
+
+```js
+{ restOfPath: "components/Button", fileName: "Button", extension: "tsx" }
 ```
 
 When several matching descriptors capture values, those values are **merged** into a single `file.captured` object.


### PR DESCRIPTION
# Fix fileDescriptors capture

## eslint-plugin

### Fixed

- fix(#457): Upgrade `@boundaries/elements` to v3.0.1. File descriptors now honor a plain `capture` array without requiring `basePattern`. Previously, `capture` on a `boundaries/files` descriptor without `basePattern` always resulted in `file.captured` being `null`.

## elements

### Fixed

- fix(#457): File descriptors now honor a plain `capture` array without requiring `basePattern`. Previously, `capture` on a `boundaries/files` descriptor without `basePattern` always resulted in `file.captured` being `null`.

## Agreement

Please check the following boxes after you have read and understood each item.

* [x] I have read the [CONTRIBUTING](https://github.com/javierbrea/eslint-plugin-boundaries/blob/master/.github/CONTRIBUTING.md) document
* [x] I have read the [CODE_OF_CONDUCT](https://github.com/javierbrea/eslint-plugin-boundaries/blob/master/.github/CODE_OF_CONDUCT.md) document
* [x] I have read the [CONTRIBUTOR LICENSE AGREEMENT](https://github.com/javierbrea/eslint-plugin-boundaries/blob/master/.github/CLA.md) document, and I agree to the terms and declare that all my contributions are compliant with it.

closes #457 
