### PR TITLE
fix(#460): boundaries/dependencies no longer skips external/core dependencies

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [7.0.2] - 2026-07-07
+
+### Fixed
+
+- fix(#460): `boundaries/dependencies` no longer skips external/core dependencies when their resolved target file is ignored (e.g. `node_modules` paths outside `boundaries/include`). With `checkAllOrigins: true`, these dependencies now reach policy evaluation, matching the documented migration path from the deprecated `boundaries/external` rule.
+
 ## [7.0.1] - 2026-07-06
 
 ### Fixed

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boundaries/eslint-plugin",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "Eslint plugin checking architecture boundaries between elements",
   "keywords": [
     "eslint",

--- a/packages/eslint-plugin/sonar-project.properties
+++ b/packages/eslint-plugin/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=javierbrea
 sonar.projectKey=javierbrea_eslint-plugin-boundaries
-sonar.projectVersion=7.0.1
+sonar.projectVersion=7.0.2
 
 sonar.javascript.file.suffixes=.js
 sonar.sourceEncoding=UTF-8

--- a/packages/eslint-plugin/src/Rules/Dependencies.spec.ts
+++ b/packages/eslint-plugin/src/Rules/Dependencies.spec.ts
@@ -1560,6 +1560,129 @@ describe("Dependencies", () => {
       expect(getElementsMatcherMock).not.toHaveBeenCalled();
     });
 
+    it("still skips local dependencies with dependency.to.file.isIgnored when checkAllOrigins is true", () => {
+      const matcher = createMatcher();
+      getElementsMatcherMock.mockReturnValue(matcher);
+      const dependency = createDependencyDescription({
+        to: createEntityDescription({
+          file: { isIgnored: true },
+          module: { origin: ORIGINS_MAP.LOCAL },
+        }),
+      });
+
+      callHandler(
+        RULE_NAMES_MAP.DEPENDENCIES,
+        createCallArgs(dependency, { checkAllOrigins: true })
+      );
+
+      expect(getElementsMatcherMock).not.toHaveBeenCalled();
+    });
+
+    it("evaluates ignored external modules when checkAllOrigins is true", () => {
+      const matcher = createMatcher();
+      getElementsMatcherMock.mockReturnValue(matcher);
+      const fn = matcher.getDependencySelectorMatchingDescription as jest.Mock;
+      fn.mockReturnValueOnce({ matched: true });
+
+      const dependency = createDependencyDescription({
+        to: createEntityDescription({
+          file: { isIgnored: true },
+          module: { origin: ORIGINS_MAP.EXTERNAL, source: "zod" },
+        }),
+        dependency: {
+          source: "zod",
+          kind: "value",
+          nodeKind: "ImportDeclaration",
+          specifiers: ["z"],
+          relationship: { from: "sibling", to: "sibling" },
+        },
+      });
+      const args = createCallArgs(dependency, {
+        checkAllOrigins: true,
+        default: "disallow",
+        policies: [
+          {
+            from: { element: { type: "default" } },
+            allow: {
+              to: { module: { origin: "external", source: "zod" } },
+            },
+          },
+        ],
+      });
+
+      callHandler(RULE_NAMES_MAP.DEPENDENCIES, args);
+
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(args.context.report).not.toHaveBeenCalled();
+    });
+
+    it("reports ignored external modules not covered by an allow policy when checkAllOrigins is true", () => {
+      const matcher = createMatcher();
+      getElementsMatcherMock.mockReturnValue(matcher);
+
+      const dependency = createDependencyDescription({
+        to: createEntityDescription({
+          file: { isIgnored: true },
+          module: { origin: ORIGINS_MAP.EXTERNAL, source: "zod" },
+        }),
+        dependency: {
+          source: "zod",
+          kind: "value",
+          nodeKind: "ImportDeclaration",
+          specifiers: ["z"],
+          relationship: { from: "sibling", to: "sibling" },
+        },
+      });
+      const args = createCallArgs(dependency, {
+        checkAllOrigins: true,
+        default: "disallow",
+        policies: [],
+      });
+
+      callHandler(RULE_NAMES_MAP.DEPENDENCIES, args);
+
+      expect(getElementsMatcherMock).toHaveBeenCalledTimes(1);
+      expect(args.context.report).toHaveBeenCalledTimes(1);
+    });
+
+    it("evaluates ignored core modules when checkAllOrigins is true", () => {
+      const matcher = createMatcher();
+      getElementsMatcherMock.mockReturnValue(matcher);
+      const fn = matcher.getDependencySelectorMatchingDescription as jest.Mock;
+      fn.mockReturnValueOnce({ matched: true });
+
+      const dependency = createDependencyDescription({
+        to: createEntityDescription({
+          file: { isIgnored: true },
+          module: { origin: ORIGINS_MAP.CORE, source: "fs" },
+        }),
+        dependency: {
+          source: "fs",
+          kind: "value",
+          nodeKind: "ImportDeclaration",
+          specifiers: ["readFileSync"],
+          relationship: { from: "sibling", to: "sibling" },
+        },
+      });
+      const args = createCallArgs(dependency, {
+        checkAllOrigins: true,
+        default: "disallow",
+        policies: [
+          {
+            from: { element: { type: "default" } },
+            allow: {
+              to: { module: { origin: "core", source: "fs" } },
+            },
+          },
+        ],
+      });
+
+      callHandler(RULE_NAMES_MAP.DEPENDENCIES, args);
+
+      expect(fn).toHaveBeenCalledTimes(1);
+      expect(args.context.report).not.toHaveBeenCalled();
+    });
+
     it("skips evaluation when dependency.from.file.isIgnored is true", () => {
       const matcher = createMatcher();
       getElementsMatcherMock.mockReturnValue(matcher);

--- a/packages/eslint-plugin/src/Rules/Dependencies.ts
+++ b/packages/eslint-plugin/src/Rules/Dependencies.ts
@@ -825,7 +825,7 @@ export default function getDependencyRule(
         DEPENDENCY_RELATIONSHIPS_MAP.INTERNAL;
 
       if (
-        !dependency.to.file.isIgnored &&
+        (!dependency.to.file.isIgnored || !isLocalDependency) &&
         !dependency.from.file.isIgnored &&
         (checkAllOrigins || isLocalDependency) &&
         (checkUnknownLocals || !isUnknownLocalDependency) &&

--- a/packages/eslint-plugin/test/rules/one-level/external-v7.spec.ts
+++ b/packages/eslint-plugin/test/rules/one-level/external-v7.spec.ts
@@ -848,6 +848,76 @@ testCapture(
   }
 );
 
+// checkAllOrigins evaluates external dependencies even when their resolved
+// file is ignored, e.g. because it lives in node_modules, outside
+// `boundaries/include` (regression test for
+// https://github.com/javierbrea/eslint-plugin-boundaries/issues/460).
+const testCheckAllOriginsWithIgnoredExternalDependencies = () => {
+  const settings = {
+    ...SETTINGS.oneLevel,
+    "boundaries/include": [codeFilePath("**/*.js")],
+  };
+  const ruleTester = createRuleTester(settings);
+
+  ruleTester.run(
+    `${RULE} - checkAllOrigins with ignored external dependencies`,
+    rule,
+    {
+      valid: [
+        // "micromatch" resolves to a real file in node_modules, which is
+        // ignored because it is outside `boundaries/include`. It should
+        // still be allowed by an explicit policy.
+        {
+          filename: absoluteFilePath("helpers/helper-a/HelperA.js"),
+          code: "import micromatch from 'micromatch'",
+          options: [
+            {
+              checkAllOrigins: true,
+              default: "disallow",
+              policies: [
+                {
+                  from: { element: { type: "helpers" } },
+                  allow: [
+                    {
+                      to: {
+                        module: { origin: "external", source: "micromatch" },
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      invalid: [
+        // Same ignored "micromatch" dependency, but with no policy allowing
+        // it: it must still be reported, proving that checkAllOrigins
+        // reaches policy evaluation despite `to.file.isIgnored` being true.
+        {
+          filename: absoluteFilePath("components/component-a/ComponentA.js"),
+          code: "import micromatch from 'micromatch'",
+          options: [
+            {
+              checkAllOrigins: true,
+              default: "disallow",
+            },
+          ],
+          errors: [
+            {
+              message:
+                'There is no policy allowing dependencies from elements of type "components" and captured values: elementName="component-a" to entities of module with origin "external" and module source "micromatch"',
+              type: "Literal",
+            },
+          ],
+        },
+      ],
+    }
+  );
+};
+
+testCheckAllOriginsWithIgnoredExternalDependencies();
+
 const noRulesTester = createRuleTester(SETTINGS.oneLevel);
 noRulesTester.run(RULE, rule, {
   valid: [


### PR DESCRIPTION
## eslint-plugin

### Fixed

- fix(#460): `boundaries/dependencies` no longer skips external/core dependencies when their resolved target file is ignored (e.g. `node_modules` paths outside `boundaries/include`). With `checkAllOrigins: true`, these dependencies now reach policy evaluation, matching the documented migration path from the deprecated `boundaries/external` rule.

## Agreement

Please check the following boxes after you have read and understood each item.

* [x] I have read the [CONTRIBUTING](https://github.com/javierbrea/eslint-plugin-boundaries/blob/master/.github/CONTRIBUTING.md) document
* [x] I have read the [CODE_OF_CONDUCT](https://github.com/javierbrea/eslint-plugin-boundaries/blob/master/.github/CODE_OF_CONDUCT.md) document
* [x] I have read the [CONTRIBUTOR LICENSE AGREEMENT](https://github.com/javierbrea/eslint-plugin-boundaries/blob/master/.github/CLA.md) document, and I agree to the terms and declare that all my contributions are compliant with it.

closes #460
