### PR TITLE
feat(#430): Make `name` required in `boundaries/additional-dependency-nodes`

### DIFF
--- a/packages/eslint-plugin/CHANGELOG.md
+++ b/packages/eslint-plugin/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [unreleased]
+
+### Changed
+
+- feat(#430): The `name` property is now required in `boundaries/additional-dependency-nodes`. Objects without a valid `name` are considered invalid and ignored, emitting a warning, instead of being accepted with a soft suggestion.
+
+### BREAKING CHANGES
+
+- Custom dependency nodes defined in `boundaries/additional-dependency-nodes` without a `name` property were previously accepted; now they are ignored. Add a unique `name` to each custom dependency node, so it can be referenced from selectors (`dependency.nodeKind`) and custom messages templates.
+
 ## [7.0.2] - 2026-07-07
 
 ### Fixed

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@boundaries/eslint-plugin",
-  "version": "7.0.2",
+  "version": "8.0.0",
   "description": "Eslint plugin checking architecture boundaries between elements",
   "keywords": [
     "eslint",

--- a/packages/eslint-plugin/sonar-project.properties
+++ b/packages/eslint-plugin/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.organization=javierbrea
 sonar.projectKey=javierbrea_eslint-plugin-boundaries
-sonar.projectVersion=7.0.2
+sonar.projectVersion=8.0.0
 
 sonar.javascript.file.suffixes=.js
 sonar.sourceEncoding=UTF-8

--- a/packages/eslint-plugin/src/Settings/Settings.spec.ts
+++ b/packages/eslint-plugin/src/Settings/Settings.spec.ts
@@ -148,16 +148,16 @@ describe("Settings/Settings", () => {
       expect(mockedWarnOnce).not.toHaveBeenCalled();
     });
 
-    it("returns true and warns when a valid selector omits the name", () => {
+    it("returns false and warns when the selector omits the name", () => {
       expect(
         isValidDependencyNodeSelector({
           selector: "CallExpression",
           kind: "value",
         })
-      ).toBe(true);
+      ).toBe(false);
       expect(mockedWarnOnce).toHaveBeenCalledTimes(1);
       expect(mockedWarnOnce).toHaveBeenCalledWith(
-        expect.stringContaining(`"name"`),
+        expect.stringContaining(SETTINGS.ADDITIONAL_DEPENDENCY_NODES),
         expect.any(String)
       );
     });
@@ -189,6 +189,16 @@ describe("Settings/Settings", () => {
           selector: "CallExpression",
           kind: "value",
           name: 1,
+        })
+      ).toBe(false);
+    });
+
+    it("returns false when name is an empty string", () => {
+      expect(
+        isValidDependencyNodeSelector({
+          selector: "CallExpression",
+          kind: "value",
+          name: "",
         })
       ).toBe(false);
     });
@@ -698,6 +708,34 @@ describe("Settings/Settings", () => {
         expect(mockedWarnOnce).toHaveBeenCalledWith(
           expect.stringContaining(SETTINGS.ADDITIONAL_DEPENDENCY_NODES),
           expect.stringContaining(JSON.stringify([{ kind: "value" }]))
+        );
+      });
+
+      it("filters additional nodes without a name and warns about them", () => {
+        const valid = {
+          selector: "CallExpression",
+          kind: "value" as const,
+          name: "custom",
+        };
+        const withoutName = {
+          selector: "CallExpression",
+          kind: "value" as const,
+        };
+        const result = getSettings(
+          buildContext({
+            [SETTINGS_KEYS_MAP.ELEMENTS]: [validElementDescriptor],
+            [SETTINGS_KEYS_MAP.DEPENDENCY_NODES]: [],
+            [SETTINGS_KEYS_MAP.ADDITIONAL_DEPENDENCY_NODES]: [
+              valid,
+              withoutName,
+            ],
+          })
+        );
+
+        expect(result.dependencyNodes).toEqual([valid]);
+        expect(mockedWarnOnce).toHaveBeenCalledWith(
+          expect.stringContaining(SETTINGS.ADDITIONAL_DEPENDENCY_NODES),
+          expect.stringContaining(JSON.stringify([withoutName]))
         );
       });
     });

--- a/packages/eslint-plugin/src/Settings/Settings.spec.ts
+++ b/packages/eslint-plugin/src/Settings/Settings.spec.ts
@@ -202,6 +202,16 @@ describe("Settings/Settings", () => {
         })
       ).toBe(false);
     });
+
+    it("returns false when name is only whitespace", () => {
+      expect(
+        isValidDependencyNodeSelector({
+          selector: "CallExpression",
+          kind: "value",
+          name: "   ",
+        })
+      ).toBe(false);
+    });
   });
 
   describe("deprecateTypes", () => {

--- a/packages/eslint-plugin/src/Settings/Settings.ts
+++ b/packages/eslint-plugin/src/Settings/Settings.ts
@@ -140,17 +140,13 @@ export function isValidDependencyNodeSelector(
     isObject(selector) &&
     isString(selector.selector) &&
     (!selector.kind || isDependencyKind(selector.kind)) &&
-    (!selector.name || isString(selector.name));
+    isString(selector.name) &&
+    selector.name.length > 0;
 
   if (!isValidObject) {
     warnOnce(
       `Please provide a valid object in ${ADDITIONAL_DEPENDENCY_NODES} setting.`,
-      `The object should be composed of the following properties: { selector: "<esquery selector>", kind: "value" | "type", name: "<string>" (optional) }. The invalid object will be ignored. ${moreInfoSettingsLink()}`
-    );
-  } else if (isObject(selector) && !selector.name) {
-    warnOnce(
-      `Consider adding a "name" property to your custom dependency node for using it in selectors and custom messages.`,
-      moreInfoSettingsLink()
+      `The object should be composed of the following properties: { selector: "<esquery selector>", kind: "value" | "type", name: "<string>" }. The invalid object will be ignored. ${moreInfoSettingsLink()}`
     );
   }
   return isValidObject;
@@ -601,7 +597,7 @@ function getNormalizedAdditionalDependencyNodes(
   if (!isArray(additionalNodes)) {
     warnOnce(
       `Invalid ${ADDITIONAL_DEPENDENCY_NODES} setting format.`,
-      `It should be an array containing objects with properties: { selector: "<esquery selector>", kind: "value" | "type", name: "<string>" (optional) }. ${moreInfoSettingsLink()}`
+      `It should be an array containing objects with properties: { selector: "<esquery selector>", kind: "value" | "type", name: "<string>" }. ${moreInfoSettingsLink()}`
     );
     return [];
   }

--- a/packages/eslint-plugin/src/Settings/Settings.ts
+++ b/packages/eslint-plugin/src/Settings/Settings.ts
@@ -141,7 +141,7 @@ export function isValidDependencyNodeSelector(
     isString(selector.selector) &&
     (!selector.kind || isDependencyKind(selector.kind)) &&
     isString(selector.name) &&
-    selector.name.length > 0;
+    selector.name.trim().length > 0;
 
   if (!isValidObject) {
     warnOnce(

--- a/packages/eslint-plugin/src/Shared/Settings.types.ts
+++ b/packages/eslint-plugin/src/Shared/Settings.types.ts
@@ -172,8 +172,8 @@ export type DependencyNodeSelector = {
   selector: string;
   /** The kind of import, either 'type' or 'value' */
   kind: DependencyKind;
-  /** Name to assign to the dependency node. Useful to identify the kind of node selector in rules */
-  name?: string;
+  /** Name to assign to the dependency node. Used to identify the kind of node selector in rules and custom messages */
+  name: string;
 };
 
 export const SETTINGS = {

--- a/packages/eslint-plugin/test/rules/one-level/element-types-dependency-nodes-legacy.spec.ts
+++ b/packages/eslint-plugin/test/rules/one-level/element-types-dependency-nodes-legacy.spec.ts
@@ -35,6 +35,7 @@ const dependencyNodesSettings = {
     {
       // mock('source')
       selector: "CallExpression[callee.name=mock] > Literal",
+      name: "mock",
     },
   ],
 };

--- a/packages/eslint-plugin/test/rules/one-level/external-dependency-nodes-legacy.spec.ts
+++ b/packages/eslint-plugin/test/rules/one-level/external-dependency-nodes-legacy.spec.ts
@@ -29,6 +29,7 @@ const dependencyNodesSettings = {
     {
       // mock('source')
       selector: "CallExpression[callee.name=mock] > Literal",
+      name: "mock",
     },
   ],
 };

--- a/packages/eslint-plugin/test/rules/one-level/external-dependency-nodes-v7.spec.ts
+++ b/packages/eslint-plugin/test/rules/one-level/external-dependency-nodes-v7.spec.ts
@@ -30,6 +30,7 @@ const dependencyNodesSettings = {
     {
       // mock('source')
       selector: "CallExpression[callee.name=mock] > Literal",
+      name: "mock",
     },
   ],
 };

--- a/packages/eslint-plugin/test/rules/one-level/external-dependency-nodes.spec.ts
+++ b/packages/eslint-plugin/test/rules/one-level/external-dependency-nodes.spec.ts
@@ -29,6 +29,7 @@ const dependencyNodesSettings = {
     {
       // mock('source')
       selector: "CallExpression[callee.name=mock] > Literal",
+      name: "mock",
     },
   ],
 };

--- a/packages/eslint-plugin/test/rules/one-level/invalid-settings.spec.ts
+++ b/packages/eslint-plugin/test/rules/one-level/invalid-settings.spec.ts
@@ -174,12 +174,13 @@ runTest(
   {
     "boundaries/additional-dependency-nodes": [
       // valid
-      { selector: "Selector", kind: "value" },
-      { selector: "Selector", kind: "type" },
+      { selector: "Selector", kind: "value", name: "custom-value" },
+      { selector: "Selector", kind: "type", name: "custom-type" },
       // invalid
-      { selector: "Selector", kind: "unknown-kind" },
-      { selector: 0, kind: "value" },
-      { kind: "value" },
+      { selector: "Selector", kind: "value" },
+      { selector: "Selector", kind: "unknown-kind", name: "custom" },
+      { selector: 0, kind: "value", name: "custom" },
+      { kind: "value", name: "custom" },
       { unknown: "object" },
       "import",
       "any-string",

--- a/packages/website/docs/settings/settings.md
+++ b/packages/website/docs/settings/settings.md
@@ -170,11 +170,11 @@ Defines custom dependency nodes to analyze beyond the built-in ones. All plugin 
 **Object structure:**
 
 - **`selector`** - The [esquery selector](https://github.com/estools/esquery) for the `Literal` node where the dependency source is defined
-- **`name`** (optional) - A name for the custom node, so you can **use it in policy configuration using `dependency.nodeKind`** (e.g., to forbid or allow this kind of dependency node in some rules or to use it in custom messages templates variables)
+- **`name`** - A name for the custom node, so you can **use it in policy configuration using `dependency.nodeKind`** (e.g., to forbid or allow this kind of dependency node in some rules or to use it in custom messages templates variables)
 - **`kind`** - Assigns the **`dependency.kind` property in dependency descriptions**, which you can use in policy configuration or custom message templates to target specific dependency kinds. Possible values are `"value"`, `"type"`, or `"typeof"`.
 
 :::warning
-The `name` property is optional for the moment, but if you don't provide it, the plugin will not be able to identify the node kind of the dependency in policy configuration or custom messages templates, so it will be treated as a generic dependency without a specific node kind. If you want to use the custom node in policy configuration or custom messages templates, make sure to provide a unique name for it.
+The `name` property is required. Custom dependency nodes defined without a unique `name` cannot be referenced from selectors or custom messages templates, so objects missing it are considered invalid and are ignored (a warning is emitted).
 :::
 
 **Example:**


### PR DESCRIPTION
## Description

### Problem

With the object-based selector syntax introduced in #386, custom dependency nodes are referenced from selectors through `dependency.nodeKind`, and `name` is the identifier used for that. A node defined without `name` cannot be targeted from selectors or custom messages templates, so it is incomplete in the new model — yet the plugin accepted it with only a soft `warnOnce` suggestion.

### Fix

- `isValidDependencyNodeSelector` (`packages/eslint-plugin/src/Settings/Settings.ts`) now requires `name` to be a non-empty string (an empty string could never be referenced from selectors either). Objects missing it take the same rejection path as any other invalid object: they are ignored and the "Please provide a valid object" warning is emitted (message updated to drop the `(optional)` marker, as is the array-format message in `getNormalizedAdditionalDependencyNodes`). The soft "Consider adding a name" branch is removed.
- `DependencyNodeSelector.name` (`packages/eslint-plugin/src/Shared/Settings.types.ts`) is now `name: string` (was `name?: string`). This type is exported publicly through `Public/Settings.types.ts`, so typed configs get compile-time enforcement. Note: settings are not validated through a JSON schema anywhere in the codebase (the JSON schemas in `Settings/Rules.ts` cover rule options only), so the exported type plus the runtime guard are the whole validation surface.
- Docs: `packages/website/docs/settings/settings.md` — `name` is no longer marked `(optional)` and the "optional for the moment" admonition now states the property is required and that nodes missing it are ignored with a warning. Versioned docs for 7.0.0 are intentionally untouched (the property is still optional there).
- Fixtures that relied on nameless custom nodes (`element-types-dependency-nodes-legacy`, `external-dependency-nodes{,-legacy,-v7}` specs) now declare `name: "mock"`, matching their v7 siblings; `invalid-settings.spec.ts` reclassifies a nameless node as invalid.
- CHANGELOG: `[unreleased]` section with a `BREAKING CHANGES` note. `package.json` and `sonar.projectVersion` bumped to `8.0.0` per the versioning guide and the issue's v8.0.0 milestone — happy to drop/adjust the bump if you prefer to handle it during release preparation.

### Tests

- `Settings.spec.ts`: rewrote the "valid selector omitting name" case — it now asserts rejection via the invalid-object warning path — added an empty-string `name` rejection case, and added a `getSettings`-level case asserting a nameless node is filtered out of `dependencyNodes` and reported in the invalid-nodes warning. All fail without the fix.
- Full `eslint-plugin` unit suite (118 suites / 5724 tests), `check:types`, `lint`, and `check:spell` pass.

closes #430

## Agreement

* [x] I have read the [CONTRIBUTING](https://github.com/javierbrea/eslint-plugin-boundaries/blob/master/.github/CONTRIBUTING.md) document
* [x] I have read the [CODE_OF_CONDUCT](https://github.com/javierbrea/eslint-plugin-boundaries/blob/master/.github/CODE_OF_CONDUCT.md) document
* [x] I have read the [CONTRIBUTOR LICENSE AGREEMENT](https://github.com/javierbrea/eslint-plugin-boundaries/blob/master/.github/CLA.md) document, and I agree to the terms and declare that all my contributions are compliant with it.
