### PR TITLE
feat(#440): Add TypeScript example to the monorepo and point the docs to it

### DIFF
--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -1,0 +1,50 @@
+# TypeScript example
+
+Minimal example of configuring `eslint-plugin-boundaries` in a TypeScript project, as described in the [TypeScript Support guide](https://www.jsboundaries.dev/docs/guides/typescript-support/).
+
+It demonstrates:
+
+- Parsing TypeScript files with `@typescript-eslint/parser`.
+- Resolving TypeScript imports with `eslint-import-resolver-typescript`, including the path aliases defined in [`tsconfig.json`](./tsconfig.json) (`@helpers/*`, `@components/*`).
+- Classifying files into elements (`helper`, `component`, `module`) and enforcing dependency policies between them with the [`boundaries/dependencies` rule](https://www.jsboundaries.dev/docs/rules/dependencies/).
+
+## Structure
+
+```
+src/
+├── helpers/
+│   └── format-message/   # helper: can't depend on anything
+├── components/
+│   └── message/          # component: can depend on helpers
+└── modules/
+    └── printer/          # module: can depend on components and helpers
+```
+
+## Usage
+
+From the repository root:
+
+```bash
+pnpm install
+pnpm nx lint example-typescript
+```
+
+Nx builds the local `eslint-plugin` package before linting, so the example always runs against the sources of this repository. After the plugin is built, you can also run ESLint directly from this folder:
+
+```bash
+pnpm lint
+```
+
+Linting passes because every import complies with the configured policies. To see the plugin in action, add a disallowed dependency and run it again. For example, import a module from a component in `src/components/message/index.ts`:
+
+```ts
+import printFormattedMessage from "../../modules/printer";
+```
+
+## Using this example outside the repository
+
+The example depends on the local plugin sources through the `workspace:` protocol. To use it as a template for your own project, replace the `eslint-plugin-boundaries` version in `package.json` with the one published in the npm registry:
+
+```json
+"eslint-plugin-boundaries": "latest"
+```

--- a/examples/typescript/cspell.config.cjs
+++ b/examples/typescript/cspell.config.cjs
@@ -1,0 +1,3 @@
+const { createConfig } = require("../../support/cspell-config/index.js");
+
+module.exports = createConfig();

--- a/examples/typescript/eslint.config.js
+++ b/examples/typescript/eslint.config.js
@@ -1,0 +1,52 @@
+import typescriptEslintPlugin from "@typescript-eslint/eslint-plugin";
+import typescriptParser from "@typescript-eslint/parser";
+import boundaries from "eslint-plugin-boundaries";
+
+export default [
+  {
+    ignores: ["node_modules/**"],
+  },
+  {
+    files: ["src/**/*.ts"],
+    languageOptions: {
+      parser: typescriptParser,
+    },
+    plugins: {
+      "@typescript-eslint": typescriptEslintPlugin,
+      boundaries,
+    },
+    settings: {
+      "boundaries/elements": [
+        { type: "helper", pattern: "helpers/*" },
+        { type: "component", pattern: "components/*" },
+        { type: "module", pattern: "modules/*" },
+      ],
+      // Resolves TypeScript imports, including the path aliases defined in tsconfig.json
+      "import/resolver": {
+        typescript: {
+          alwaysTryTypes: true,
+        },
+      },
+    },
+    rules: {
+      ...typescriptEslintPlugin.configs.recommended.rules,
+      ...boundaries.configs.recommended.rules,
+      "boundaries/dependencies": [
+        2,
+        {
+          default: "disallow",
+          policies: [
+            {
+              from: { element: { types: "component" } },
+              allow: { to: { element: { types: "helper" } } },
+            },
+            {
+              from: { element: { types: "module" } },
+              allow: { to: { element: { types: ["component", "helper"] } } },
+            },
+          ],
+        },
+      ],
+    },
+  },
+];

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@boundaries/example-typescript",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Example of configuring eslint-plugin-boundaries in a TypeScript project",
+  "author": "Javier Brea",
+  "license": "MIT",
+  "scripts": {
+    "check:all": "echo 'All checks passed'",
+    "check:spell": "cspell --quiet .",
+    "check:types": "tsc --noEmit",
+    "eslint": "eslint",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "8.57.0",
+    "@typescript-eslint/parser": "8.57.0",
+    "eslint": "9.37.0",
+    "eslint-import-resolver-typescript": "4.4.4",
+    "eslint-plugin-boundaries": "workspace:@boundaries/eslint-plugin@*",
+    "typescript": "5.9.3"
+  }
+}

--- a/examples/typescript/project.json
+++ b/examples/typescript/project.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "name": "example-typescript",
+  "projectType": "application",
+  "tags": ["type:example"],
+  "targets": {
+    "lint": {
+      "cache": true,
+      "inputs": [
+        { "dependentTasksOutputFiles": "**/*", "transitive": true },
+        "default"
+      ],
+      "dependsOn": ["^build"]
+    }
+  },
+  "implicitDependencies": ["eslint-plugin", "cspell-config"]
+}

--- a/examples/typescript/src/components/message/index.ts
+++ b/examples/typescript/src/components/message/index.ts
@@ -1,0 +1,8 @@
+// Example of import using a tsconfig path alias
+import formatMessage from "@helpers/format-message";
+
+function printMessage(message: string): void {
+  console.log(formatMessage(message));
+}
+
+export default printMessage;

--- a/examples/typescript/src/helpers/format-message/index.ts
+++ b/examples/typescript/src/helpers/format-message/index.ts
@@ -1,0 +1,5 @@
+function formatMessage(message: string): string {
+  return `[example] ${message}`;
+}
+
+export default formatMessage;

--- a/examples/typescript/src/modules/printer/index.ts
+++ b/examples/typescript/src/modules/printer/index.ts
@@ -1,0 +1,12 @@
+// Example of import using a tsconfig path alias
+import printMessage from "@components/message";
+
+// Example of import using a relative path
+import formatMessage from "../../helpers/format-message";
+
+function printFormattedMessage(message: string): void {
+  console.log(formatMessage(message));
+  printMessage(message);
+}
+
+export default printFormattedMessage;

--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "baseUrl": "./src",
+    "paths": {
+      "@helpers/*": ["helpers/*"],
+      "@components/*": ["components/*"]
+    },
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/website/CHANGELOG.md
+++ b/packages/website/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [unreleased]
 ### Added
 ### Changed
+- docs(#440): Point the TypeScript Support guide to the new in-repo `examples/typescript` folder instead of the standalone `epb-ts-example` repository.
 ### Fixed
 ### Removed
 ### Breaking Changes

--- a/packages/website/docs/guides/typescript-support.md
+++ b/packages/website/docs/guides/typescript-support.md
@@ -208,7 +208,7 @@ If you encounter issues with TypeScript support:
 2. Verify that `eslint-import-resolver-typescript` is configured in settings
 3. Check that your `tsconfig.json` is valid and accessible
 4. Confirm that the TypeScript parser is correctly specified in `languageOptions`
-5. Refer to the example repository for a known working configuration
+5. Refer to the [TypeScript example](https://github.com/javierbrea/eslint-plugin-boundaries/tree/master/examples/typescript) in the repository for a known working configuration
 
 ## Further Reading
 

--- a/packages/website/versioned_docs/version-7.0.0/guides/typescript-support.md
+++ b/packages/website/versioned_docs/version-7.0.0/guides/typescript-support.md
@@ -208,7 +208,7 @@ If you encounter issues with TypeScript support:
 2. Verify that `eslint-import-resolver-typescript` is configured in settings
 3. Check that your `tsconfig.json` is valid and accessible
 4. Confirm that the TypeScript parser is correctly specified in `languageOptions`
-5. Refer to the example repository for a known working configuration
+5. Refer to the [TypeScript example](https://github.com/javierbrea/eslint-plugin-boundaries/tree/master/examples/typescript) in the repository for a known working configuration
 
 ## Further Reading
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,27 @@ importers:
         specifier: 5.9.3
         version: 5.9.3
 
+  examples/typescript:
+    devDependencies:
+      '@typescript-eslint/eslint-plugin':
+        specifier: 8.57.0
+        version: 8.57.0(@typescript-eslint/parser@8.57.0(eslint@9.37.0(jiti@1.21.7))(typescript@5.9.3))(eslint@9.37.0(jiti@1.21.7))(typescript@5.9.3)
+      '@typescript-eslint/parser':
+        specifier: 8.57.0
+        version: 8.57.0(eslint@9.37.0(jiti@1.21.7))(typescript@5.9.3)
+      eslint:
+        specifier: 9.37.0
+        version: 9.37.0(jiti@1.21.7)
+      eslint-import-resolver-typescript:
+        specifier: 4.4.4
+        version: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.37.0(jiti@1.21.7))
+      eslint-plugin-boundaries:
+        specifier: workspace:@boundaries/eslint-plugin@*
+        version: link:../../packages/eslint-plugin
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+
   packages/elements:
     dependencies:
       eslint-import-resolver-node:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,5 @@
 packages:
+  - examples/*
   - packages/*
   - support/*
   - test/*


### PR DESCRIPTION
## Description

### Problem

The TypeScript reference setup lives in the standalone [epb-ts-example](https://github.com/javierbrea/epb-ts-example) repository, which is already outdated (v4 legacy config, deprecated `element-types` rule and `mode: "full"` descriptors) and is not exercised against the current plugin sources.

### Changes

- **New `examples/typescript/` workspace package** migrating the epb-ts-example content to the current plugin version:
  - `eslint.config.js` follows the [TypeScript Support guide](https://www.jsboundaries.dev/docs/guides/typescript-support/): `@typescript-eslint/parser`, `eslint-import-resolver-typescript` (resolving the `@helpers/*` / `@components/*` aliases from `tsconfig.json`), the `recommended` preset, and a `boundaries/dependencies` policy over three element types (`helper`, `component`, `module`).
  - `src/` contains one element of each type, using both alias and relative imports, all compliant with the configured policies. The README shows how to introduce a violation to see the rule fire.
  - The plugin is consumed as `"eslint-plugin-boundaries": "workspace:@boundaries/eslint-plugin@*"` — an aliased workspace dependency, so the config reads exactly like end-user code while always linking the local sources. The README explains how to swap it for the published version when copying the example.
  - `examples/*` is added to `pnpm-workspace.yaml`, and `project.json` declares `implicitDependencies` on `eslint-plugin` (build ordering) and `cspell-config`, plus a `lint` target that depends on `^build`. Since the package defines `check:all`, the example is linted, type-checked, and spell-checked by the existing `nx run-many -t check:all --all` CI gate, so it cannot silently rot.
- **Docs**: the Troubleshooting section of `guides/typescript-support.md` (current docs and `versioned_docs/version-7.0.0`) now links to the in-repo example instead of the generic "example repository" mention. Website CHANGELOG updated under `[unreleased]`.

### Verification

- `pnpm nx check:all example-typescript` passes (lint + check:types + check:spell, building the plugin first).
- From `examples/typescript`, `pnpm eslint .` exits 0; adding a component→module import reports a `boundaries/dependencies` violation as expected.

### Out of scope

Archiving `javierbrea/epb-ts-example` and pointing it to the new location is a maintainer-only action (issue bullet 2), so this PR does not fully close the issue on its own.

Refs #440

## Agreement

* [x] I have read the [CONTRIBUTING](https://github.com/javierbrea/eslint-plugin-boundaries/blob/master/.github/CONTRIBUTING.md) document
* [x] I have read the [CODE_OF_CONDUCT](https://github.com/javierbrea/eslint-plugin-boundaries/blob/master/.github/CODE_OF_CONDUCT.md) document
* [x] I have read the [CONTRIBUTOR LICENSE AGREEMENT](https://github.com/javierbrea/eslint-plugin-boundaries/blob/master/.github/CLA.md) document, and I agree to the terms and declare that all my contributions are compliant with it.
